### PR TITLE
README: headline decode table with hybrid Mamba-2 rows; Nemotron-3 Nano llama.cpp vs MLX bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # Apple Silicon LLM Benchmark
 
+**Decode tok/s, batch 1, greedy, warm — same model, same harness (details and raw JSONL below):**
+
+| Model | Device | Apple Core AI | MLX | llama.cpp | Core ML |
+|---|---|---:|---:|---:|---:|
+| Qwen3-0.6B 4-bit | iPhone 17 Pro | **181** (GPU pipelined) / 49 (ANE) | 112 | — | 39 (ANE, 184 MB) |
+| Qwen3-0.6B 4-bit | M4 Max | 1,121 (macOS-26 export) / ~500 (27β export) | 455 | — | — |
+| Qwen3-8B 4-bit | M4 Max | 94 | 90 | — | — |
+| Nemotron-3 Nano 4B (hybrid Mamba-2) | M4 Max | 85.2 (int8 head) | 176.8 | 88.4 | — |
+| Nemotron-3 Nano 4B (hybrid Mamba-2) | iPhone 17 Pro | 16.0 (AOT) | — | — | — |
+| Nemotron-3 Nano 30B-A3B (hybrid MoE) | M4 Max | — | 159.7 | 86.2 | — |
+| Granite-4.0-H 1B (hybrid Mamba-2) | iPhone 17 Pro / M4 Max | 35 / 136 | — | — | — |
+| Granite-4.0-H Tiny (hybrid MoE) | M4 Max | — | 202.2 | 117.3 | — |
+
+Hybrid-model llama.cpp / MLX rows: [`results/hybrid/nemotron3-nano-apple-silicon-bench.md`](results/hybrid/nemotron3-nano-apple-silicon-bench.md) (M4 Max, 2026-09-04; quantization is not equal across columns — unsloth Q4_K_M ≈ 6.2 bpw, Core AI 4B is int8-head — see the caveats there). Nemotron-3 Nano 4B and Granite-4.0-H Core AI rows: [`mlboydaisuke/Nemotron-3-Nano-4B-CoreAI`](https://huggingface.co/mlboydaisuke/Nemotron-3-Nano-4B-CoreAI), [`coreai-community/granite-4.0-h-CoreAI`](https://huggingface.co/coreai-community/granite-4.0-h-CoreAI).
+
 **On-device LLM benchmark for Apple Silicon — iPhone · iPad · Mac.**
 
 A neutral, reproducible benchmark for running local LLMs (and, in time, ASR / TTS) on Apple Silicon. Compares **MLX Swift, llama.cpp, CoreML (swift-transformers), LiteRT-LM, ExecuTorch, ANEMLL, Apple Core AI** — and Apple's own Foundation Models — under real device constraints, not just `tok/s` on a server.

--- a/results/hybrid/nemotron3-nano-apple-silicon-bench.json
+++ b/results/hybrid/nemotron3-nano-apple-silicon-bench.json
@@ -1,0 +1,151 @@
+{
+  "title": "Nemotron-3 Nano on Apple Silicon: llama.cpp vs MLX, batch 1, greedy, 4-bit",
+  "date": "2026-09-04",
+  "hardware": {
+    "cpu": "Apple M4 Max",
+    "hw_memsize_bytes": 137438953472,
+    "memory_gib": 128,
+    "os": "macOS 27.0 (26A5416b)",
+    "xcode": "Xcode 27.0 (27A5237l), /Applications/Xcode-27.0.0-Beta.5.app",
+    "power": "mains, lid open, no other GPU workload during measurements"
+  },
+  "software": {
+    "llama_cpp": {
+      "source": "Homebrew package llama.cpp",
+      "build": 8680,
+      "commit": "15f786e65",
+      "backends_reported": "BLAS,MTL",
+      "threads_reported": 12,
+      "note": "Homebrew binary loaded both nemotron_h (4B) and nemotron_h_moe (30B-A3B) GGUFs, so no source build was made. ggml_metal_device_init printed 'tensor API disabled for pre-M5 and pre-A19 devices'."
+    },
+    "mlx": "0.32.2",
+    "mlx_lm": "0.31.3",
+    "python": "3.12.13 (venv)",
+    "huggingface_hub": "1.30.0"
+  },
+  "protocol": {
+    "batch_size": 1,
+    "sampling": "greedy (llama-bench has no sampling; llama-completion --temp 0; mlx_lm generate --temp 0)",
+    "llama_bench_args": "-p 512 -n 256 -ngl 99 -fa 1 -r 3",
+    "llama_bench_metric": "pp512 / tg256 tokens per second, mean +/- std over 3 repetitions as printed",
+    "mlx_metric": "mlx_lm 'Prompt:' and 'Generation:' tokens-per-sec and 'Peak memory' as printed; median of 3 separate processes; prompt = 133 tokens after chat template (~100-word user prompt), 256 generated tokens",
+    "prompt_tps_caveat": "llama-bench pp512 processes a synthetic 512-token batch; mlx-lm prompt tok/s is measured on a 133-token chat prompt. The two prompt columns are not the same measurement.",
+    "peak_memory_caveat": "llama.cpp: maximum resident set size from /usr/bin/time -l around an identical llama-bench run (includes mmapped weights). MLX: 'Peak memory' printed by mlx-lm (Metal allocations). Different metrics; do not compare across stacks at face value.",
+    "weight_size_caveat": "The unsloth Q4_K_M GGUF for 30B-A3B is 24.57 GB (~6.2 bits/weight average for 31.58B params), whereas the mlx-community 4-bit is 17.78 GB. Bytes per token differ between the two 30B-A3B rows.",
+    "downloads": "HF_HOME=/private/tmp/odp-bench/hf HF_HUB_DISABLE_XET=1; all models deleted after the run"
+  },
+  "results": [
+    {
+      "model": "NVIDIA Nemotron-3 Nano 30B-A3B",
+      "architecture": "nemotron_h_moe (hybrid Mamba-2 / Transformer MoE, 31.58B total, ~3.5B active)",
+      "stack": "llama.cpp (Metal)",
+      "stack_version": "Homebrew build 8680, commit 15f786e65",
+      "repo": "unsloth/Nemotron-3-Nano-30B-A3B-GGUF",
+      "revision": "9ad8b366c308f931b2a96b9306f0b41aef9cd405",
+      "file": "Nemotron-3-Nano-30B-A3B-Q4_K_M.gguf",
+      "file_bytes": 24574373664,
+      "quant": "Q4_K_M",
+      "model_buffer_gib_reported": 22.88,
+      "prompt_tps": {"test": "pp512", "mean": 1212.81, "std": 3.02},
+      "decode_tps": {"test": "tg256", "mean": 86.19, "std": 0.47},
+      "fa0_run": {"pp512": {"mean": 1207.08, "std": 3.25}, "tg256": {"mean": 85.73, "std": 0.34}},
+      "repeat_run_with_rss": {"pp512": {"mean": 1214.61, "std": 3.01}, "tg256": {"mean": 86.84, "std": 0.57}},
+      "peak_memory": {"metric": "max RSS (/usr/bin/time -l)", "bytes": 24380833792, "gb": 24.38},
+      "llama_completion_check": {"prompt_eval_tps": 116.10, "eval_tps": 86.59, "n_predict": 160, "note": "single-turn chat, 34 prompt tokens, 127 generated; default n_ctx was 1048576 so its memory breakdown is not representative"},
+      "notes": "-fa 1 and -fa 0 within noise."
+    },
+    {
+      "model": "NVIDIA Nemotron-3 Nano 30B-A3B",
+      "architecture": "nemotron_h_moe",
+      "stack": "MLX (mlx-lm)",
+      "stack_version": "mlx 0.32.2, mlx-lm 0.31.3",
+      "repo": "mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit",
+      "revision": "832f602eba5d22436c258c1462bdedc5afddb42b",
+      "file": "model-0000{1..4}-of-00004.safetensors",
+      "file_bytes_total": 17780000000,
+      "quant": "4-bit (mlx-community)",
+      "prompt_tps": {"test": "133-token chat prompt", "median": 642.55, "runs": [154.212, 642.680, 642.547], "note": "first process was slower on prompt (cold start); decode unaffected"},
+      "decode_tps": {"test": "256 tokens", "median": 159.714, "runs": [159.714, 159.600, 159.775]},
+      "peak_memory": {"metric": "mlx-lm 'Peak memory'", "gb_median": 18.349, "runs_gb": [18.248, 18.349, 18.349]},
+      "notes": "Chat template enables reasoning by default; most of the 256 generated tokens are the reasoning trace."
+    },
+    {
+      "model": "NVIDIA Nemotron-3 Nano 4B",
+      "architecture": "nemotron_h (dense hybrid Mamba-2 / Transformer, 3.97B)",
+      "stack": "llama.cpp (Metal)",
+      "stack_version": "Homebrew build 8680, commit 15f786e65",
+      "repo": "nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF",
+      "revision": "ba223d14e45525f7fae81db77ea8cabeb2fc6c25",
+      "file": "NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf",
+      "file_bytes": 2837072864,
+      "quant": "Q4_K_M",
+      "model_buffer_gib_reported": 2.63,
+      "prompt_tps": {"test": "pp512", "mean": 1308.83, "std": 1.05},
+      "decode_tps": {"test": "tg256", "mean": 88.38, "std": 0.22},
+      "repeat_run_with_rss": {"pp512": {"mean": 1309.95, "std": 1.69}, "tg256": {"mean": 88.03, "std": 0.13}},
+      "peak_memory": {"metric": "max RSS (/usr/bin/time -l)", "bytes": 3020849152, "gb": 3.02},
+      "llama_completion_check": {"prompt_eval_tps": 201.14, "eval_tps": 88.48, "n_predict": 160, "note": "single-turn chat, 34 prompt tokens, 84 generated"},
+      "notes": "Decode tok/s is nearly identical to the 30B-A3B row despite a 9x smaller weight file; not investigated further here."
+    },
+    {
+      "model": "NVIDIA Nemotron-3 Nano 4B",
+      "architecture": "nemotron_h",
+      "stack": "MLX (mlx-lm)",
+      "stack_version": "mlx 0.32.2, mlx-lm 0.31.3",
+      "repo": "mlx-community/NVIDIA-Nemotron-3-Nano-4B-4bit",
+      "revision": "c4d79ba1901d99806ef757642a552acebb851a35",
+      "file": "model.safetensors",
+      "file_bytes_total": 2240000000,
+      "quant": "4-bit (mlx-community)",
+      "prompt_tps": {"test": "133-token chat prompt", "median": 1058.729, "runs": [970.518, 1058.729, 1260.560]},
+      "decode_tps": {"test": "256 tokens", "median": 176.757, "runs": [176.981, 175.799, 176.757]},
+      "peak_memory": {"metric": "mlx-lm 'Peak memory'", "gb_median": 3.213, "runs_gb": [3.213, 3.213, 3.213]},
+      "notes": "Chat template enables reasoning by default; output has a reasoning trace, then </think>, then the answer."
+    }
+  ],
+  "coherence_samples": {
+    "prompt_llama_completion": "In two or three sentences, what is unified memory on Apple Silicon and why does it matter for running LLMs locally?",
+    "prompt_mlx": "You are a helpful assistant. In about 150 words, explain to a software engineer who has never used Apple Silicon why unified memory matters for running large language models locally. Cover three points: how the GPU and CPU share the same physical memory pool, why this lets a laptop load a model that would not fit in a discrete GPU's VRAM, and what the practical trade-off is compared with a desktop GPU in terms of memory bandwidth. Keep the tone neutral and technical, avoid marketing language, and end with one sentence about when a discrete GPU is still the better choice.",
+    "nemotron_30b_a3b_llama_cpp": "**Unified memory** on Apple Silicon is a single, coherent pool of RAM that the CPU, GPU, and Neural Engine can all access directly without copying data between separate memory spaces. Because the same physical memory serves all cores, data (like model weights or activations)",
+    "nemotron_30b_a3b_mlx": "We need to produce about 150 words, neutral technical tone, covering three points: unified memory sharing, why it lets laptop load model that wouldn't fit in discrete GPU VRAM, and practical trade-off compared with desktop GPU in terms of memory bandwidth. [...] Draft: \"Unified memory on Apple Silicon is a single address space that both the CPU and GPU can access without copying data across separate pools. Because the memory is physically shared, a model's tensors reside in RAM that the GPU can read directly",
+    "nemotron_4b_llama_cpp": "**Unified memory on Apple Silicon means that the CPU, GPU, and memory controller share a single pool of memory, allowing them to communicate and access data seamlessly.** This eliminates the need for data to be copied between systems, making it faster and more efficient.",
+    "nemotron_4b_mlx": "We need to produce about 150 words, neutral technical tone, covering three points: unified memory, GPU/CPU share same physical memory pool, allows laptop to load model that wouldn't fit in discrete GPU VRAM [...] </think> Unified memory means the CPU and GPU access a single, shared physical memory pool rather than separate VRAM and system RAM. Because the model's tensors reside in this pool, a laptop can load a large language model that would otherwise exceed the discrete GPU's limited VRAM"
+  },
+  "granite_4_0_h_tiny": [
+    {
+      "model": "IBM Granite-4.0-H-Tiny",
+      "architecture": "granitehybrid (hybrid Mamba-2 / Transformer MoE, 6.94B total, 64 experts / 6 used, llama.cpp size class 7B.A1B)",
+      "stack": "llama.cpp (Metal)",
+      "stack_version": "Homebrew build 8680, commit 15f786e65",
+      "repo": "unsloth/granite-4.0-h-tiny-GGUF",
+      "revision": "56b37fdc52891304726c4a0a8b140dd1fc1582d5",
+      "file": "granite-4.0-h-tiny-Q4_K_M.gguf",
+      "file_bytes": 4254815392,
+      "quant": "Q4_K_M",
+      "model_buffer_gib_reported": 3.96,
+      "prompt_tps": {"test": "pp512", "mean": 2227.99, "std": 6.47},
+      "decode_tps": {"test": "tg256", "mean": 117.31, "std": 0.92},
+      "repeat_run_with_rss": {"pp512": {"mean": 2222.74, "std": 9.35}, "tg256": {"mean": 116.40, "std": 0.16}},
+      "peak_memory": {"metric": "max RSS (/usr/bin/time -l)", "bytes": 4426891264, "gb": 4.43},
+      "llama_completion_check": {"prompt_eval_tps": 230.17, "eval_tps": 116.79, "n_predict": 160, "note": "single-turn chat, 33 prompt tokens, 66 generated"},
+      "coherence_sample": "Unified memory on Apple Silicon refers to the architecture where the CPU and GPU share a single pool of memory, allowing for seamless data transfer between the two components. This is important for running large language models (LLMs) locally because it enables efficient memory management",
+      "notes": "Measured with no concurrent download."
+    },
+    {
+      "model": "IBM Granite-4.0-H-Tiny",
+      "architecture": "granitehybrid",
+      "stack": "MLX (mlx-lm)",
+      "stack_version": "mlx 0.32.2, mlx-lm 0.31.3",
+      "repo": "lmstudio-community/granite-4.0-h-tiny-MLX-4bit",
+      "revision": "a0f1fb8fdb387c4bd90e23e5e3f7ba9f7438b921",
+      "file": "model.safetensors",
+      "file_bytes_total": 3906536789,
+      "quant": "4-bit affine, group_size 64, MoE router layers 8-bit (from config.json)",
+      "prompt_tps": {"test": "123-token chat prompt", "median": 1525.079, "runs": [280.065, 1564.625, 1525.079], "note": "first process slower on prompt (cold start)"},
+      "decode_tps": {"test": "244 tokens (EOS before 256)", "median": 202.181, "runs": [201.491, 202.181, 202.827]},
+      "peak_memory": {"metric": "mlx-lm 'Peak memory'", "gb_median": 4.436, "runs_gb": [4.436, 4.436, 4.436]},
+      "coherence_sample": "Unified memory is a key feature of Apple Silicon that significantly impacts how large language models are run locally on laptops. Firstly, in Apple Silicon, the GPU and CPU share the same physical memory pool, which means there's no discrete VRAM.",
+      "notes": "mlx-community/granite-4.0-h-tiny-4bit was attempted first but its download stayed under 5 MB/s (0-1 MB/s on resume) for over ten minutes and was abandoned; the lmstudio-community conversion downloaded at 11 MB/s. No reasoning trace in the output."
+    }
+  ]
+}

--- a/results/hybrid/nemotron3-nano-apple-silicon-bench.md
+++ b/results/hybrid/nemotron3-nano-apple-silicon-bench.md
@@ -1,0 +1,108 @@
+# Nemotron-3 Nano on Apple Silicon: llama.cpp vs MLX (batch 1, greedy, 4-bit)
+
+Measured 2026-09-04 on one machine. Structured copy of the same numbers: `nemotron3-nano-apple-silicon-bench.json`.
+
+## Hardware and software
+
+- Apple M4 Max, 128 GiB unified memory (`hw.memsize` = 137438953472), macOS 27.0 (26A5416b), Xcode 27.0 beta 5 (27A5237l).
+- llama.cpp: Homebrew package, build **8680**, commit **15f786e65**, backends reported `BLAS,MTL`, 12 threads. The Homebrew binary loaded both `nemotron_h` (4B) and `nemotron_h_moe` (30B-A3B) GGUFs, so no source build was needed.
+- MLX: `mlx` **0.32.2**, `mlx-lm` **0.31.3**, Python 3.12.13 in a fresh venv.
+- Mains power, no other GPU workload during measurements.
+
+## Results
+
+| Model | Stack (version) | Weights | Prompt tok/s | Decode tok/s | Peak memory | Notes |
+|---|---|---|---:|---:|---:|---|
+| Nemotron-3 Nano 30B-A3B | llama.cpp Metal (b8680, 15f786e65) | Q4_K_M, unsloth, 24.57 GB (22.88 GiB buffer) | pp512 **1212.81 ± 3.02** | tg256 **86.19 ± 0.47** | 24.38 GB max RSS | `-fa 0`: 1207.08 ± 3.25 / 85.73 ± 0.34 |
+| Nemotron-3 Nano 30B-A3B | MLX mlx-lm 0.31.3 (mlx 0.32.2) | 4-bit, mlx-community, 17.78 GB | 642.6 (133-tok prompt) | **159.7** (median of 159.71 / 159.60 / 159.78) | 18.35 GB (mlx peak) | reasoning trace on by default |
+| Nemotron-3 Nano 4B | llama.cpp Metal (b8680, 15f786e65) | Q4_K_M, nvidia, 2.84 GB (2.63 GiB buffer) | pp512 **1308.83 ± 1.05** | tg256 **88.38 ± 0.22** | 3.02 GB max RSS | |
+| Nemotron-3 Nano 4B | MLX mlx-lm 0.31.3 (mlx 0.32.2) | 4-bit, mlx-community, 2.24 GB | 1058.7 (133-tok prompt) | **176.8** (median of 176.98 / 175.80 / 176.76) | 3.21 GB (mlx peak) | reasoning trace on by default |
+
+How to read the columns:
+
+- llama.cpp numbers are `llama-bench` output, mean ± std over `-r 3`. A second identical run wrapped in `/usr/bin/time -l` (for RSS) gave 1214.61 ± 3.01 / 86.84 ± 0.57 (30B-A3B) and 1309.95 ± 1.69 / 88.03 ± 0.13 (4B), i.e. run-to-run drift is under 1%.
+- MLX numbers are what `mlx_lm generate` prints (`Prompt:` / `Generation:` tokens-per-sec, `Peak memory`), median of three separate processes. The MLX prompt column is a 133-token chat prompt, not a 512-token batch, so it is not the same measurement as pp512. The first 30B-A3B MLX process reported a slower prompt phase (154 tok/s, cold start); the other two agreed at 642.
+- Peak memory is a different metric per stack: max resident set size for llama.cpp (includes the mmapped weight file), Metal peak allocation as reported by mlx-lm for MLX. Do not compare them across stacks at face value.
+- The unsloth Q4_K_M for 30B-A3B is 24.57 GB, about 6.2 bits/weight averaged over 31.58 B params; the mlx-community 4-bit is 17.78 GB. The two 30B-A3B rows do not move the same number of bytes per token.
+- Observation only, not investigated: on llama.cpp the dense 4B decodes at almost the same rate as the 30B-A3B (88 vs 86 tok/s) despite a 9x smaller weight file, so decode in this build does not look weight-bandwidth-bound for these `nemotron_h` models.
+- `llama-completion` single-turn runs (34 prompt tokens, 160 max tokens) reported eval rates of 86.59 tok/s (30B-A3B) and 88.48 tok/s (4B), consistent with llama-bench.
+
+## Commands
+
+Downloads (models deleted after the run):
+
+```sh
+export HF_HOME=/private/tmp/odp-bench/hf HF_HUB_DISABLE_XET=1
+huggingface-cli download unsloth/Nemotron-3-Nano-30B-A3B-GGUF --include "*Q4_K_M*"          # rev 9ad8b366
+huggingface-cli download nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF --include "NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf"   # rev ba223d14
+huggingface-cli download mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit   # rev 832f602e
+huggingface-cli download mlx-community/NVIDIA-Nemotron-3-Nano-4B-4bit        # rev c4d79ba1
+```
+
+llama.cpp (Homebrew `llama.cpp` 8680):
+
+```sh
+llama-bench -m Nemotron-3-Nano-30B-A3B-Q4_K_M.gguf -p 512 -n 256 -ngl 99 -fa 1 -r 3
+llama-bench -m Nemotron-3-Nano-30B-A3B-Q4_K_M.gguf -p 512 -n 256 -ngl 99 -fa 0 -r 3
+llama-bench -m NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf -p 512 -n 256 -ngl 99 -fa 1 -r 3
+/usr/bin/time -l llama-bench -m <same gguf> -p 512 -n 256 -ngl 99 -fa 1 -r 3     # "maximum resident set size"
+llama-completion -m <gguf> -ngl 99 -fa on --temp 0 -n 160 -st --simple-io \
+  -p "In two or three sentences, what is unified memory on Apple Silicon and why does it matter for running LLMs locally?"
+```
+
+MLX (venv: `pip install mlx-lm`, which pulled mlx 0.32.2 / mlx-lm 0.31.3). `python -m mlx_lm.generate` is deprecated in this version and prints a warning; `python -m mlx_lm generate` is the same entry point. Run three times each:
+
+```sh
+python -m mlx_lm generate --model mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit --prompt "$(cat prompt.txt)" --max-tokens 256 --temp 0
+python -m mlx_lm generate --model mlx-community/NVIDIA-Nemotron-3-Nano-4B-4bit        --prompt "$(cat prompt.txt)" --max-tokens 256 --temp 0
+```
+
+`prompt.txt` (101 words; 133 tokens after the chat template):
+
+> You are a helpful assistant. In about 150 words, explain to a software engineer who has never used Apple Silicon why unified memory matters for running large language models locally. Cover three points: how the GPU and CPU share the same physical memory pool, why this lets a laptop load a model that would not fit in a discrete GPU's VRAM, and what the practical trade-off is compared with a desktop GPU in terms of memory bandwidth. Keep the tone neutral and technical, avoid marketing language, and end with one sentence about when a discrete GPU is still the better choice.
+
+## Coherence samples (first ~200 characters of one greedy output each)
+
+Nemotron-3 Nano 30B-A3B, llama.cpp (no reasoning block appeared in the llama.cpp chat output):
+
+> **Unified memory** on Apple Silicon is a single, coherent pool of RAM that the CPU, GPU, and Neural Engine can all access directly without copying data between separate memory spaces. Because the same physical memory serves all cores, data (like model weights or activations) …
+
+Nemotron-3 Nano 30B-A3B, MLX (mlx-lm applies the model's chat template, which turns reasoning on, so the output starts with a reasoning trace):
+
+> We need to produce about 150 words, neutral technical tone, covering three points: unified memory sharing, why it lets laptop load model that wouldn't fit in discrete GPU VRAM, and practical trade-off compared with desktop GPU in terms of memory bandwidth. […] Draft: "Unified memory on Apple Silicon is a single address space that both the CPU and GPU can access without copying data across separate pools. Because the memory is physically shared, a model's tensors reside in RAM that the GPU can read directly …
+
+Nemotron-3 Nano 4B, llama.cpp:
+
+> **Unified memory on Apple Silicon means that the CPU, GPU, and memory controller share a single pool of memory, allowing them to communicate and access data seamlessly.** This eliminates the need for data to be copied between systems, making it faster and more efficient. …
+
+Nemotron-3 Nano 4B, MLX (reasoning trace, then `</think>`, then the answer):
+
+> We need to produce about 150 words, neutral technical tone, covering three points: unified memory, GPU/CPU share same physical memory pool, allows laptop to load model that wouldn't fit in discrete GPU VRAM […] `</think>` Unified memory means the CPU and GPU access a single, shared physical memory pool rather than separate VRAM and system RAM. Because the model's tensors reside in this pool, a laptop can load a large language model that would otherwise exceed the discrete GPU's limited VRAM …
+
+## Granite-4.0-H-Tiny (second hybrid data point)
+
+Same protocol, same binaries. `ibm-granite/granite-4.0-h-tiny` is a hybrid Mamba-2 / Transformer MoE (`granitehybrid`, 6.94 B params, 64 experts, 6 used, llama.cpp size class "7B.A1B").
+
+| Model | Stack (version) | Weights | Prompt tok/s | Decode tok/s | Peak memory | Notes |
+|---|---|---|---:|---:|---:|---|
+| Granite-4.0-H-Tiny | llama.cpp Metal (b8680, 15f786e65) | Q4_K_M, unsloth rev 56b37fdc, 4.25 GB (3.96 GiB buffer) | pp512 **2227.99 ± 6.47** | tg256 **117.31 ± 0.92** | 4.43 GB max RSS | RSS run: 2222.74 ± 9.35 / 116.40 ± 0.16; llama-completion eval 116.79 tok/s |
+| Granite-4.0-H-Tiny | MLX mlx-lm 0.31.3 (mlx 0.32.2) | 4-bit affine gs64 (routers 8-bit), lmstudio-community rev a0f1fb8f, 3.91 GB | 1525 (123-tok prompt) | **202.2** (median of 201.49 / 202.18 / 202.83) | 4.44 GB (mlx peak) | stopped at 244 tokens (EOS); no reasoning trace |
+
+The MLX weights come from `lmstudio-community/granite-4.0-h-tiny-MLX-4bit` rather than `mlx-community/granite-4.0-h-tiny-4bit`: the mlx-community download stayed under 5 MB/s (0-1 MB/s on resume) for over ten minutes and was abandoned; the lmstudio-community file came down at 11 MB/s. Both are plain 4-bit mlx-lm conversions of the same base model. The first MLX process again reported a slow prompt phase (280 tok/s, cold start); the other two agreed at 1525-1565.
+
+```sh
+huggingface-cli download unsloth/granite-4.0-h-tiny-GGUF --include "granite-4.0-h-tiny-Q4_K_M.gguf"
+llama-bench -m granite-4.0-h-tiny-Q4_K_M.gguf -p 512 -n 256 -ngl 99 -fa 1 -r 3
+huggingface-cli download lmstudio-community/granite-4.0-h-tiny-MLX-4bit
+python -m mlx_lm generate --model lmstudio-community/granite-4.0-h-tiny-MLX-4bit --prompt "$(cat prompt.txt)" --max-tokens 256 --temp 0
+```
+
+Coherence samples (same prompts as above):
+
+llama.cpp:
+
+> Unified memory on Apple Silicon refers to the architecture where the CPU and GPU share a single pool of memory, allowing for seamless data transfer between the two components. This is important for running large language models (LLMs) locally because it enables efficient memory management …
+
+MLX:
+
+> Unified memory is a key feature of Apple Silicon that significantly impacts how large language models are run locally on laptops. Firstly, in Apple Silicon, the GPU and CPU share the same physical memory pool, which means there's no discrete VRAM. …


### PR DESCRIPTION
Puts the cross-runtime decode table (Core AI / MLX / llama.cpp / Core ML) at the top of the README and adds the 2026-09-04 M4 Max measurements of Nemotron-3 Nano 30B-A3B and 4B (llama.cpp b8680 vs mlx-lm 0.31.3) under results/hybrid/. Quantization caveats are inside the bench file.