### PR TITLE
README headline table generated from stored records (render_headline.py + CI); LEADERBOARD re-rendered

### DIFF
--- a/.github/workflows/results-rendered.yml
+++ b/.github/workflows/results-rendered.yml
@@ -9,6 +9,7 @@ on:
       - "android/**"
       - "RESULTS.md"
       - "LEADERBOARD.md"
+      - "README.md"
       - "evaldata/**"
       - ".github/workflows/results-rendered.yml"
   push:
@@ -59,6 +60,16 @@ jobs:
         with:
           python-version: "3.11"
       - run: python scripts/render_leaderboard.py --check
+
+  headline-check:
+    name: README headline table is rendered
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python scripts/render_headline.py --check
 
   scripts-compile:
     name: every script parses

--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -56,6 +56,13 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | mlx-swift | `mlx-community/Qwen3-1.7B-4bit` | Q4 | pre-stamp | 325.0 | 324.2 | 1009.3 | 20.0 | — | — | 2026-07-13 |
 | litert-lm | `litert-local/qwen3-1.7b-int4` | INT4 (mixed, int8 embed) | pre-stamp | 171.1 | 94.9 | — | 350.0 | — | — | 2026-07-13 |
 
+**Qwen 3 8B**
+
+| runtime | artifact | quant | engine | warm tok/s | cold tok/s | prefill tok/s | TTFT ms | mem MB | GSM8K | captured |
+|---|---|---|---|---|---|---|---|---|---|---|
+| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | pre-stamp | — | 98.3 | 242.5 | 82.0 | — | — | 2026-06-17 |
+| litert-lm | `litert-community/Qwen3-8B` | INT4 (mixed, blockwise gs32) | pre-stamp | — | 62.4 | — | 467.0 | — | — | 2026-06-17 |
+
 **Qwen 3.5 0.8B**
 
 | runtime | artifact | quant | engine | warm tok/s | cold tok/s | prefill tok/s | TTFT ms | mem MB | GSM8K | captured |
@@ -96,9 +103,8 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | apple-fm/default | apple-fm | `apple-fm/default` | Apple-quant (~2-4 bit, adapters) | pre-stamp | — | 84.3 | 2026-05-16 |
 | litert-community/DeepSeek-R1-Distill-Qwen-1.5B | litert-lm | `litert-community/DeepSeek-R1-Distill-Qwen-1.5B` | INT8 | pre-stamp | 119.0 | 119.3 | 2026-07-13 |
 | litert-community/Gemma3-1B-IT | litert-lm | `litert-community/Gemma3-1B-IT` | INT4 | pre-stamp | 181.3 | 182.0 | 2026-07-13 |
-| litert-community/Phi-4-mini-instruct | litert-lm | `litert-community/Phi-4-mini-instruct` | INT8 | pre-stamp | 64.9 | 42.0 | 2026-07-13 |
+| litert-community/Phi-4-mini-instruct | litert-lm | `litert-community/Phi-4-mini-instruct` | INT8 | pre-stamp | 64.9 ⚠spread 44% | 42.0 | 2026-07-13 |
 | litert-community/Qwen3-4B | litert-lm | `litert-community/Qwen3-4B` | INT4 (mixed, blockwise gs32) | pre-stamp | 110.9 | 111.2 | 2026-07-13 |
-| litert-community/Qwen3-8B | litert-lm | `litert-community/Qwen3-8B` | INT4 (mixed, blockwise gs32) | pre-stamp | — | 62.4 | 2026-06-17 |
 | litert-community/TinySwallow-1.5B-Instruct | litert-lm | `litert-community/TinySwallow-1.5B-Instruct` | INT8 | pre-stamp | 120.6 | 120.4 | 2026-07-13 |
 | litert-community/VibeThinker-1.5B | litert-lm | `litert-community/VibeThinker-1.5B` | INT8 | pre-stamp | 120.4 | 120.3 | 2026-07-13 |
 | litert-local/llama32-3b | litert-lm | `litert-local/llama32-3b` | INT4 | pre-stamp | 93.3 | 92.9 | 2026-07-13 |
@@ -111,7 +117,6 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | mlx-community/MiniCPM5-1B-4bit | mlx-swift | `mlx-community/MiniCPM5-1B-4bit` | Q4 | pre-stamp | — | 526.2 | 2026-06-17 |
 | mlx-community/Phi-4-mini-instruct-4bit | mlx-swift | `mlx-community/Phi-4-mini-instruct-4bit` | Q4 | pre-stamp | 169.1 | 169.0 | 2026-07-13 |
 | mlx-community/Qwen3-4B-4bit | mlx-swift | `mlx-community/Qwen3-4B-4bit` | Q4 | pre-stamp | 162.2 | 163.1 | 2026-07-13 |
-| mlx-community/Qwen3-8B-4bit | mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | pre-stamp | — | 98.3 | 2026-06-17 |
 | mlx-community/TinySwallow-1.5B-Instruct-4bit | mlx-swift | `mlx-community/TinySwallow-1.5B-Instruct-4bit` | Q4 | pre-stamp | 328.0 | 328.8 | 2026-07-13 |
 | own/DeepSeek-R1-1.5B-int4-BOCTAV4 | litert-lm | `own/DeepSeek-R1-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 136.7 | 136.6 | 2026-07-14 |
 | own/Phi-4-mini-int4-BOCTAV4-128 | litert-lm | `own/Phi-4-mini-int4-BOCTAV4-128` | INT4 (BOCTAV4 blockwise-128 OCTAV, int8 embed, static-rope) | pre-stamp | 85.4 | 83.5 | 2026-07-14 |
@@ -135,7 +140,7 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | model | runtime | artifact | quant | engine | warm tok/s | cold tok/s | captured |
 |---|---|---|---|---|---|---|---|
 | Gemma 4 E2B (QAT OptiQ) | mlx-swift | `mlx-community/gemma-4-e2b-it-qat-OptiQ-4bit` | INT4 (QAT, OptiQ) | pre-stamp | 164.7 | 165.7 | 2026-07-27 |
-| SmolLM 3B | litert-lm | `litert-local/smollm3-3b` | INT4 | pre-stamp | 67.3 | — | 2026-07-13 |
+| SmolLM 3B | litert-lm | `litert-local/smollm3-3b` | INT4 | pre-stamp | 67.3 ⚠spread 57% | — | 2026-07-13 |
 
 </details>
 
@@ -207,32 +212,32 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | core-ai/ministral-3b-gpu | core-ai | `core-ai/ministral-3b-gpu` | INT4 (dynamic) | pre-stamp | — | 29.3 | 2026-07-14 |
 | core-ai/olmo2-1b-ane | core-ai | `core-ai/olmo2-1b-ane` | 4-bit palettized (uniform g32) | pre-stamp | — | 96.3 | 2026-07-14 |
 | core-ai/olmo2-1b-gpu | core-ai | `core-ai/olmo2-1b-gpu` | INT4 (dynamic) | pre-stamp | — | 92.5 | 2026-07-14 |
-| core-ai/qwen3-4b-ane | core-ai | `core-ai/qwen3-4b-ane` | 4-bit palettized (uniform g32) | pre-stamp | 30.0 | 27.0 | 2026-07-13 |
+| core-ai/qwen3-4b-ane | core-ai | `core-ai/qwen3-4b-ane` | 4-bit palettized (uniform g32) | pre-stamp | 30.0 ⚠spread 9% | 27.0 | 2026-07-13 |
 | core-ai/qwen3-4b-gpu | core-ai | `core-ai/qwen3-4b-gpu` | INT4 (dynamic) | pre-stamp | 26.4 | 27.0 | 2026-07-13 |
 | core-ai/tinyswallow-1.5b-ane | core-ai | `core-ai/tinyswallow-1.5b-ane` | 4-bit palettized (uniform g32) | pre-stamp | — | 72.9 | 2026-07-14 |
 | core-ai/tinyswallow-1.5b-gpu | core-ai | `core-ai/tinyswallow-1.5b-gpu` | INT4 (dynamic) | pre-stamp | — | 69.7 | 2026-07-14 |
 | core-ai/vibethinker-1.5b-ane | core-ai | `core-ai/vibethinker-1.5b-ane` | 4-bit palettized (uniform g32) | pre-stamp | 73.8 | 73.4 | 2026-07-13 |
 | core-ai/vibethinker-1.5b-gpu | core-ai | `core-ai/vibethinker-1.5b-gpu` | INT4 (dynamic) | pre-stamp | — | 71.0 | 2026-07-14 |
-| litert-community/DeepSeek-R1-Distill-Qwen-1.5B | litert-lm | `litert-community/DeepSeek-R1-Distill-Qwen-1.5B` | INT8 | v0.16.0 | 26.7 | 31.2 | 2026-08-24 |
+| litert-community/DeepSeek-R1-Distill-Qwen-1.5B | litert-lm | `litert-community/DeepSeek-R1-Distill-Qwen-1.5B` | INT8 | v0.16.0 | 26.7 ⚠spread 19% | 31.2 | 2026-08-24 |
 | litert-community/Gemma3-1B-IT | litert-lm | `litert-community/Gemma3-1B-IT` | INT4 | pre-stamp | 72.1 | 72.7 | 2026-07-13 |
 | litert-community/LFM2.5-1.2B-Instruct | litert-lm | `litert-community/LFM2.5-1.2B-Instruct` | int4_gpu (litert-community descriptor) | v0.16.0 | 69.5 | 69.9 | 2026-08-26 |
-| litert-community/MiniCPM5-1B | litert-lm | `litert-community/MiniCPM5-1B` | wi4b32_wi8_afp32 (gpu-opt) | v0.16.0 | 34.2 | 36.2 | 2026-08-26 |
-| litert-community/Phi-4-mini-instruct | litert-lm | `litert-community/Phi-4-mini-instruct` | INT8 | pre-stamp | 11.6 | 11.4 | 2026-07-24 |
-| litert-community/Qwen3-4B | litert-lm | `litert-community/Qwen3-4B` | INT4 (mixed, blockwise gs32) | v0.16.0 | 16.1 | 23.1 | 2026-08-19 |
-| litert-community/TinySwallow-1.5B-Instruct | litert-lm | `litert-community/TinySwallow-1.5B-Instruct` | INT8 | pre-stamp | 29.4 | 29.2 | 2026-07-23 |
-| litert-community/VibeThinker-1.5B | litert-lm | `litert-community/VibeThinker-1.5B` | INT8 | pre-stamp | 29.3 | 30.6 | 2026-07-23 |
-| litert-local/llama32-3b | litert-lm | `litert-local/llama32-3b` | INT4 | pre-stamp | 18.2 | 19.2 | 2026-07-13 |
-| litert-local/ministral3-3b | litert-lm | `litert-local/ministral3-3b` | INT4 | pre-stamp | 18.4 | 19.0 | 2026-07-14 |
-| litert-local/olmo2-1b | litert-lm | `litert-local/olmo2-1b` | INT4 | pre-stamp | 20.6 | 26.4 | 2026-07-13 |
+| litert-community/MiniCPM5-1B | litert-lm | `litert-community/MiniCPM5-1B` | wi4b32_wi8_afp32 (gpu-opt) | v0.16.0 | 34.2 ⚠spread 14% | 36.2 | 2026-08-26 |
+| litert-community/Phi-4-mini-instruct | litert-lm | `litert-community/Phi-4-mini-instruct` | INT8 | pre-stamp | 11.6 ⚠spread 7% | 11.4 | 2026-07-24 |
+| litert-community/Qwen3-4B | litert-lm | `litert-community/Qwen3-4B` | INT4 (mixed, blockwise gs32) | v0.16.0 | 16.1 ⚠spread 60% | 23.1 | 2026-08-19 |
+| litert-community/TinySwallow-1.5B-Instruct | litert-lm | `litert-community/TinySwallow-1.5B-Instruct` | INT8 | pre-stamp | 29.4 ⚠spread 10% | 29.2 | 2026-07-23 |
+| litert-community/VibeThinker-1.5B | litert-lm | `litert-community/VibeThinker-1.5B` | INT8 | pre-stamp | 29.3 ⚠spread 22% | 30.6 | 2026-07-23 |
+| litert-local/llama32-3b | litert-lm | `litert-local/llama32-3b` | INT4 | pre-stamp | 18.2 ⚠spread 9% | 19.2 | 2026-07-13 |
+| litert-local/ministral3-3b | litert-lm | `litert-local/ministral3-3b` | INT4 | pre-stamp | 18.4 ⚠spread 14% | 19.0 | 2026-07-14 |
+| litert-local/olmo2-1b | litert-lm | `litert-local/olmo2-1b` | INT4 | pre-stamp | 20.6 ⚠spread 25% | 26.4 | 2026-07-13 |
 | mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit | mlx-swift | `mlx-community/DeepSeek-R1-Distill-Qwen-1.5B-4bit` | Q4 | pre-stamp | 73.2 | 74.5 | 2026-07-13 |
 | mlx-community/Llama-3.2-3B-Instruct-4bit | mlx-swift | `mlx-community/Llama-3.2-3B-Instruct-4bit` | Q4 | pre-stamp | 33.8 | 34.4 | 2026-07-13 |
 | mlx-community/Phi-4-mini-instruct-4bit | mlx-swift | `mlx-community/Phi-4-mini-instruct-4bit` | Q4 | pre-stamp | 29.3 | 29.5 | 2026-07-13 |
 | mlx-community/Qwen3-4B-4bit | mlx-swift | `mlx-community/Qwen3-4B-4bit` | Q4 | pre-stamp | 28.0 | 28.4 | 2026-07-13 |
 | mlx-community/TinySwallow-1.5B-Instruct-4bit | mlx-swift | `mlx-community/TinySwallow-1.5B-Instruct-4bit` | Q4 | pre-stamp | 72.9 | 72.6 | 2026-07-13 |
-| own/DeepSeek-R1-1.5B-int4-BOCTAV4 | litert-lm | `own/DeepSeek-R1-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 44.5 | 45.8 | 2026-07-24 |
+| own/DeepSeek-R1-1.5B-int4-BOCTAV4 | litert-lm | `own/DeepSeek-R1-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 44.5 ⚠spread 8% | 45.8 | 2026-07-24 |
 | own/Phi-4-mini-int4-BOCTAV4-128 | litert-lm | `own/Phi-4-mini-int4-BOCTAV4-128` | INT4 (BOCTAV4 blockwise-128 OCTAV, int8 embed, static-rope) | pre-stamp | 17.5 | 17.6 | 2026-07-24 |
-| own/TinySwallow-1.5B-int4-BOCTAV4 | litert-lm | `own/TinySwallow-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 45.6 | 46.8 | 2026-07-23 |
-| own/VibeThinker-1.5B-int4-BOCTAV4 | litert-lm | `own/VibeThinker-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 45.7 | 46.8 | 2026-07-23 |
+| own/TinySwallow-1.5B-int4-BOCTAV4 | litert-lm | `own/TinySwallow-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 45.6 ⚠spread 7% | 46.8 | 2026-07-23 |
+| own/VibeThinker-1.5B-int4-BOCTAV4 | litert-lm | `own/VibeThinker-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 45.7 ⚠spread 8% | 46.8 | 2026-07-23 |
 
 </details>
 
@@ -243,6 +248,8 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 - `core-ai core-ai/qwen3-1.7b-ane short-chat` — invoke-fail-bd71203
 
 ## android
+
+Android decode spans are not budget-matched across arms: llama-cli caps at the 128-token task budget, while `litert_lm_main` runs to the model's own stop (441–1037 generated tokens per run in the raw records) — v0.16.0 has no working output cap on that binary. LiteRT decode rates reproduce within ~1% across sessions, so the longer span is not visibly depressing them, but the asymmetry is real and per-run token counts are in `results/raw/` (budget-mode-rule; methodology/android.md).
 
 ### Pixel 8a
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,70 @@
 # Apple Silicon LLM Benchmark
 
-**Decode tok/s, batch 1, greedy, warm — same model, same harness (details and raw JSONL below):**
+<!-- BEGIN GENERATED: scripts/render_headline.py -->
 
-| Model | Device | Apple Core AI | MLX | llama.cpp | Core ML |
+**Decode tok/s, batch 1, greedy.** Generated from stored records by `scripts/render_headline.py` (newest record 2026-09-05) — do not edit inside the markers. Full standings with prefill, TTFT, memory and GSM8K: [LEADERBOARD.md](LEADERBOARD.md); every capture: [RESULTS.md](RESULTS.md) and `results/`. No cross-cell ratios are printed here on purpose: cells are compared only within one session, and the session is part of every cell.
+
+**Harness cells** — task `short-chat` (same prompt and 128-token budget for every arm, in-tree harness, per-run JSONL under `results/raw/`). **Bold** = warm, the median of one session's in-process runs (run 1 of every launch dropped as cold); "cold" = fresh-process first generation, shown where a session has no warm runs. Only runs that started thermal-nominal count ([fairness-rules §2](methodology/fairness-rules.md)), and each cell is its newest qualifying session — the date in parentheses. Several artifacts of one runtime are listed fastest-first, never pooled.
+
+| Model | Device | Apple Core AI | MLX | LiteRT-LM | Core ML |
 |---|---|---:|---:|---:|---:|
-| Qwen3-0.6B 4-bit | iPhone 17 Pro | **181** (GPU pipelined) / 49 (ANE) | 112 | — | 39 (ANE, 184 MB) |
-| Qwen3-0.6B 4-bit | M4 Max | 1,121 (macOS-26 export) / ~500 (27β export) | 455 | — | — |
-| Qwen3-8B 4-bit | M4 Max | 94 | 90 | — | — |
-| Nemotron-3 Nano 4B (hybrid Mamba-2) | M4 Max | 85.2 (int8 head) | 176.8 | 88.4 | — |
-| Nemotron-3 Nano 4B (hybrid Mamba-2) | iPhone 17 Pro | 16.0 (AOT) | — | — | — |
-| Nemotron-3 Nano 30B-A3B (hybrid MoE) | M4 Max | — | 159.7 | 86.2 | — |
-| Granite-4.0-H 1B (hybrid Mamba-2) | iPhone 17 Pro / M4 Max | 35 / 136 | — | — | — |
-| Granite-4.0-H Tiny (hybrid MoE) | M4 Max | — | 202.2 | 117.3 | — |
+| Qwen 3 0.6B ¹ | iPhone 17 Pro | 193.3 cold `qwen3-0.6b-gpu` (2026-06-18)<br>**122.4** `qwen3-0.6b-ane-june` (2026-07-13)<br>**116.9** `qwen3-0.6b-ane` (2026-07-13) | **178.8** (2026-08-26) | **122.1** (2026-08-26) | 37.7 cold (2026-06-17) |
+| Qwen 3 0.6B | Mac Studio (M4 Max) | — | **555.9** (2026-08-17) | **309.9** (2026-08-17) | — |
+| Qwen 3 8B | Mac Studio (M4 Max) | — | 98.3 cold (2026-06-17) | 62.4 cold (2026-06-17) | — |
 
-Hybrid-model llama.cpp / MLX rows: [`results/hybrid/nemotron3-nano-apple-silicon-bench.md`](results/hybrid/nemotron3-nano-apple-silicon-bench.md) (M4 Max, 2026-09-04; quantization is not equal across columns — unsloth Q4_K_M ≈ 6.2 bpw, Core AI 4B is int8-head — see the caveats there). Nemotron-3 Nano 4B and Granite-4.0-H Core AI rows: [`mlboydaisuke/Nemotron-3-Nano-4B-CoreAI`](https://huggingface.co/mlboydaisuke/Nemotron-3-Nano-4B-CoreAI), [`coreai-community/granite-4.0-h-CoreAI`](https://huggingface.co/coreai-community/granite-4.0-h-CoreAI).
+¹ Qwen 3 0.6B · iPhone 17 Pro: the cells come from 5 capture sessions (Apple Core AI 2026-06-18 and 2026-07-13 (`2026-07-14-iphone-final`); MLX 2026-08-26 (`2026-08-26-iphone-lfm-pair`); LiteRT-LM 2026-08-26 (`2026-08-26-iphone-qwen-3runtime-pair`); Core ML 2026-06-17). Same device, different sittings — device state moved between sessions on this phone (`results/raw/2026-07-13-mlx-variance/`), so a ratio between two cells of this row is not a measurement; compare within one session (the Core AI section below carries the per-session tables).
+
+<details><summary>Recipes behind the harness cells (quant-per-arm-rule)</summary>
+
+- iPhone 17 Pro · Qwen 3 0.6B · Apple Core AI: `core-ai/qwen3-0.6b-gpu` — INT4 (dynamic), engine pre-stamp, cold, 3 fresh-process launches in that session (no warm runs), last one shown, session 2026-06-18; newer capture on 2026-08-26 started hot and did not qualify (thermal guard)
+- iPhone 17 Pro · Qwen 3 0.6B · Apple Core AI: `core-ai/qwen3-0.6b-ane` — 4-bit palettized (uniform g32), engine pre-stamp, warm median of 3 in-process runs, session 2026-07-13 (`2026-07-14-iphone-final`)
+- iPhone 17 Pro · Qwen 3 0.6B · Apple Core AI: `core-ai/qwen3-0.6b-ane-june` — mixed 4/8-bit (June static export), engine pre-stamp, warm median of 3 in-process runs, session 2026-07-13 (`2026-07-14-iphone-final`)
+- iPhone 17 Pro · Qwen 3 0.6B · MLX: `mlx-community/Qwen3-0.6B-4bit` — Q4, engine 60bd0d7880c82980f9481f8be78862e9b63c58a3, warm median of 2 in-process runs, session 2026-08-26 (`2026-08-26-iphone-lfm-pair`)
+- iPhone 17 Pro · Qwen 3 0.6B · LiteRT-LM: `litert-community/Qwen3-0.6B` — INT4 (mixed, blockwise gs32), engine v0.16.0, warm median of 3 in-process runs, session 2026-08-26 (`2026-08-26-iphone-qwen-3runtime-pair`)
+- iPhone 17 Pro · Qwen 3 0.6B · Core ML: `coreml-llm/qwen3-0.6b` — INT8 palettized, engine pre-stamp, cold, 1 fresh-process launch in that session (no warm runs), last one shown, session 2026-06-17
+- Mac Studio (M4 Max) · Qwen 3 0.6B · MLX: `mlx-community/Qwen3-0.6B-4bit` — Q4, engine 60bd0d7880c82980f9481f8be78862e9b63c58a3, warm median of 2 in-process runs, session 2026-08-17 (`2026-08-17-mac-litert-v0160`)
+- Mac Studio (M4 Max) · Qwen 3 0.6B · LiteRT-LM: `litert-community/Qwen3-0.6B` — INT4 (mixed, blockwise gs32), engine v0.16.0, warm median of 3 in-process runs, session 2026-08-17 (`2026-08-17-mac-litert-v0160`)
+- Mac Studio (M4 Max) · Qwen 3 8B · MLX: `mlx-community/Qwen3-8B-4bit` — Q4, engine pre-stamp, cold, 3 fresh-process launches in that session (no warm runs), last one shown, session 2026-06-17
+- Mac Studio (M4 Max) · Qwen 3 8B · LiteRT-LM: `litert-community/Qwen3-8B` — INT4 (mixed, blockwise gs32), engine pre-stamp, cold, 3 fresh-process launches in that session (no warm runs), last one shown, session 2026-06-17
+
+</details>
+
+**Hybrid Mamba-2 / Transformer models, CLI runs** — llama.cpp = `llama-bench` tg256 (pp512 prompt), MLX = `mlx_lm generate` 256 tokens; greedy, batch 1, mains power, one machine. Quantization is **not** equal across columns (Q4_K_M is not 4-bit affine — see the recipes and the caveats in each report); ‡ = the report records a coherence problem with that output. Reports: `results/hybrid/hybrid-apple-silicon-bench-2.json`, `results/hybrid/nemotron3-nano-apple-silicon-bench.json`.
+
+| Model | Device | MLX | llama.cpp | Measured |
+|---|---|---:|---:|---|
+| NVIDIA Nemotron-3 Nano 30B-A3B | Apple M4 Max | 159.7 | 86.2 | 2026-09-04 |
+| NVIDIA Nemotron-3 Nano 4B | Apple M4 Max | 176.8 | 88.4 | 2026-09-04 |
+| IBM Granite-4.0-H-Tiny | Apple M4 Max | 202.2 | 117.3 | 2026-09-04 |
+| Granite-4.0-H 350M | Apple M4 Max | 521.7 | 282.5 | 2026-09-05 |
+| Granite-4.0-H 1B | Apple M4 Max | 275.8 | 141.9 | 2026-09-05 |
+| Falcon-H1 1.5B-Instruct | Apple M4 Max | 300.0 ‡ | 147.5 | 2026-09-05 |
+| Falcon-H1 3B-Instruct | Apple M4 Max | 167.9 ‡ | 86.4 | 2026-09-05 |
+| Falcon-H1 7B-Instruct | Apple M4 Max | — | 52.7 | 2026-09-05 |
+
+<details><summary>Recipes behind the hybrid cells</summary>
+
+- NVIDIA Nemotron-3 Nano 30B-A3B · MLX: mlx-community/NVIDIA-Nemotron-3-Nano-30B-A3B-4bit 4-bit (mlx-community) (mlx 0.32.2, mlx-lm 0.31.3; 256 tokens, median of 3 processes)
+- NVIDIA Nemotron-3 Nano 30B-A3B · llama.cpp: unsloth/Nemotron-3-Nano-30B-A3B-GGUF Q4_K_M (Homebrew build 8680, commit 15f786e65; tg256 mean of 3 (±0.47))
+- NVIDIA Nemotron-3 Nano 4B · MLX: mlx-community/NVIDIA-Nemotron-3-Nano-4B-4bit 4-bit (mlx-community) (mlx 0.32.2, mlx-lm 0.31.3; 256 tokens, median of 3 processes)
+- NVIDIA Nemotron-3 Nano 4B · llama.cpp: nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF Q4_K_M (Homebrew build 8680, commit 15f786e65; tg256 mean of 3 (±0.22))
+- IBM Granite-4.0-H-Tiny · MLX: lmstudio-community/granite-4.0-h-tiny-MLX-4bit 4-bit affine, group_size 64, MoE router layers 8-bit (from config.json) (mlx 0.32.2, mlx-lm 0.31.3; 244 tokens (EOS before 256), median of 3 processes)
+- IBM Granite-4.0-H-Tiny · llama.cpp: unsloth/granite-4.0-h-tiny-GGUF Q4_K_M (Homebrew build 8680, commit 15f786e65; tg256 mean of 3 (±0.92))
+- Granite-4.0-H 350M · MLX: mlx-community/granite-4.0-h-350m-4bit rev 2b96c1f6 (mlx 0.32.2, mlx-lm 0.31.3; 256-token generation, median of 3 processes)
+- Granite-4.0-H 350M · llama.cpp: ibm-granite/granite-4.0-h-350m-GGUF Q4_K_M rev a864f823 (llama.cpp build 8680 Homebrew; tg256 mean of 3 (±1.38))
+- Granite-4.0-H 1B · MLX: mlx-community/granite-4.0-h-1b-4bit rev a5a21e23 (mlx 0.32.2, mlx-lm 0.31.3; 256-token generation, median of 3 processes)
+- Granite-4.0-H 1B · llama.cpp: ibm-granite/granite-4.0-h-1b-GGUF Q4_K_M rev c2cb1972 (llama.cpp build 8680 Homebrew; tg256 mean of 3 (±1.69))
+- Falcon-H1 1.5B-Instruct · MLX: mlx-community/Falcon-H1-1.5B-Instruct-4bit rev 6f5e4f68 (mlx 0.32.2, mlx-lm 0.31.3; 256-token generation, median of 3 processes) — ‡ degenerates into repetition after ~2 sentences on the long prompt
+- Falcon-H1 1.5B-Instruct · llama.cpp: tiiuae/Falcon-H1-1.5B-Instruct-GGUF Q4_K_M rev 0d3a6cfe (llama.cpp build 8680 Homebrew; tg256 mean of 3 (±0.87))
+- Falcon-H1 3B-Instruct · MLX: own 4-bit gs64 affine from tiiuae bf16 rev 01087ec4 with mlx-lm 0.31.3 (4.504 bpw) (mlx 0.32.2, mlx-lm 0.31.3; 256-token generation, median of 3 processes) — ‡ fluent but muddled
+- Falcon-H1 3B-Instruct · llama.cpp: own Q4_K_M from tiiuae/Falcon-H1-3B-Instruct bf16 rev 01087ec4 via convert_hf_to_gguf.py (llama.cpp 8680) + llama-quantize, 4.79 BPW (llama.cpp build 8680 Homebrew; tg256 mean of 3 (±0.01))
+- Falcon-H1 7B-Instruct · llama.cpp: tiiuae/Falcon-H1-7B-Instruct-GGUF Q4_K_M rev 058c8c8f (llama.cpp build 8680 Homebrew; tg256 mean of 3 (±0.19))
+
+</details>
+
+<!-- END GENERATED: scripts/render_headline.py -->
+
+Not in the generated table yet, because this repo holds no record for them: the Apple Core AI numbers for the hybrid models live on the model cards ([`mlboydaisuke/Nemotron-3-Nano-4B-CoreAI`](https://huggingface.co/mlboydaisuke/Nemotron-3-Nano-4B-CoreAI), [`coreai-community/granite-4.0-h-CoreAI`](https://huggingface.co/coreai-community/granite-4.0-h-CoreAI)), and the M4 Max Core AI `llm-benchmark` runs are quoted in the Core AI section below with their raw logs.
 
 **On-device LLM benchmark for Apple Silicon — iPhone · iPad · Mac.**
 

--- a/RESULTS.md
+++ b/RESULTS.md
@@ -417,17 +417,17 @@ Each sub-table fixes the *logical* model (Gemma 4 E2B, Qwen 3.5 2B, …) and var
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
 | mlx-swift | `mlx-community/Qwen3-0.6B-4bit` | Q4 | 1 | 0.5 | 395 | 7050.1 | 390.1 | — | 2384 |
 
+### Qwen 3 8B  (Mac M4 Max, long-context)
+
+| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|
+| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | 1 | 1.0 | 3075 | 876.0 | 88.3 | — | 6856 |
+
 ### mlx-community/Qwen3-4B-4bit  (Mac M4 Max, long-context)
 
 | Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
 | mlx-swift | `mlx-community/Qwen3-4B-4bit` | Q4 | 1 | 0.7 | 1735 | 1558.5 | 137.9 | — | 4793 |
-
-### mlx-community/Qwen3-8B-4bit  (Mac M4 Max, long-context)
-
-| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | 1 | 1.0 | 3075 | 876.0 | 88.3 | — | 6856 |
 
 ### Qwen 3 0.6B  (Mac M4 Max, long-context-32k)
 
@@ -441,17 +441,17 @@ Each sub-table fixes the *logical* model (Gemma 4 E2B, Qwen 3.5 2B, …) and var
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
 | mlx-swift | `mlx-community/Qwen3-0.6B-4bit` | Q4 | 1 | 0.6 | 1909 | 5750.6 | 218.9 | — | 15578 |
 
+### Qwen 3 8B  (Mac M4 Max, long-context-8k)
+
+| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|
+| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | 1 | 0.6 | 14158 | 759.6 | 72.0 | — | 23751 |
+
 ### mlx-community/Qwen3-4B-4bit  (Mac M4 Max, long-context-8k)
 
 | Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
 | mlx-swift | `mlx-community/Qwen3-4B-4bit` | Q4 | 1 | 0.7 | 8799 | 1224.7 | 100.7 | — | 21652 |
-
-### mlx-community/Qwen3-8B-4bit  (Mac M4 Max, long-context-8k)
-
-| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | 1 | 0.6 | 14158 | 759.6 | 72.0 | — | 23751 |
 
 ### Gemma 4 E2B  (Mac M4 Max, quality)
 
@@ -553,6 +553,13 @@ Each sub-table fixes the *logical* model (Gemma 4 E2B, Qwen 3.5 2B, …) and var
 | litert-lm | `litert-local/qwen3-1.7b-int4` | INT4 (mixed, int8 embed) | 5 | 3.9 | 351 | — | 94.9 | 171.1 | 1778 |
 | mlx-swift | `mlx-community/Qwen3-1.7B-4bit` | Q4 | 5 | 32.7 | 65 | 309.6 | 324.2 | 325.0 | 1267 |
 
+### Qwen 3 8B  (Mac M4 Max, short-chat)
+
+| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|
+| litert-lm | `litert-community/Qwen3-8B` | INT4 (mixed, blockwise gs32) | 3 | 3.5 | 467 | — | 65.2 | — | 3451 |
+| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | 3 | 0.7 | 82 | 242.5 | 98.3 | — | 4757 |
+
 ### Qwen 3.5 0.8B  (Mac M4 Max, short-chat)
 
 | Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
@@ -612,12 +619,6 @@ Each sub-table fixes the *logical* model (Gemma 4 E2B, Qwen 3.5 2B, …) and var
 | Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
 | litert-lm | `litert-community/Qwen3-4B` | INT4 (mixed, blockwise gs32) | 5 | 6.0 | 228 | — | 111.2 | 110.9 | 2479 |
-
-### litert-community/Qwen3-8B  (Mac M4 Max, short-chat)
-
-| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| litert-lm | `litert-community/Qwen3-8B` | INT4 (mixed, blockwise gs32) | 3 | 3.5 | 467 | — | 65.2 | — | 3451 |
 
 ### litert-community/TinySwallow-1.5B-Instruct  (Mac M4 Max, short-chat)
 
@@ -691,12 +692,6 @@ Each sub-table fixes the *logical* model (Gemma 4 E2B, Qwen 3.5 2B, …) and var
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
 | mlx-swift | `mlx-community/Qwen3-4B-4bit` | Q4 | 5 | 67.5 | 56 | 370.3 | 163.1 | 162.2 | 2527 |
 
-### mlx-community/Qwen3-8B-4bit  (Mac M4 Max, short-chat)
-
-| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | 3 | 0.7 | 82 | 242.5 | 98.3 | — | 4757 |
-
 ### mlx-community/TinySwallow-1.5B-Instruct-4bit  (Mac M4 Max, short-chat)
 
 | Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
@@ -755,6 +750,13 @@ Each sub-table fixes the *logical* model (Gemma 4 E2B, Qwen 3.5 2B, …) and var
 | litert-lm | `litert-community/Qwen3-0.6B` | INT4 (mixed, blockwise gs32) | 1 | 0.6 | 54 | — | 265.8 | — | 793 |
 | mlx-swift | `mlx-community/Qwen3-0.6B-4bit` | Q4 | 1 | 0.6 | 745 | 31.0 | 474.4 | — | 816 |
 
+### Qwen 3 8B  (Mac M4 Max, sustained-generation)
+
+| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
+|---|---|---|---:|---:|---:|---:|---:|---:|---:|
+| litert-lm | `litert-community/Qwen3-8B` | INT4 (mixed, blockwise gs32) | 1 | 2.3 | 347 | — | 67.2 | — | 2104 |
+| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | 1 | 0.6 | 73 | 331.0 | 93.2 | — | 4977 |
+
 ### apple-fm/default  (Mac M4 Max, sustained-generation)
 
 | Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
@@ -767,23 +769,11 @@ Each sub-table fixes the *logical* model (Gemma 4 E2B, Qwen 3.5 2B, …) and var
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
 | litert-lm | `litert-community/Qwen3-4B` | INT4 (mixed, blockwise gs32) | 1 | 1.4 | 202 | — | 109.8 | — | 1560 |
 
-### litert-community/Qwen3-8B  (Mac M4 Max, sustained-generation)
-
-| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| litert-lm | `litert-community/Qwen3-8B` | INT4 (mixed, blockwise gs32) | 1 | 2.3 | 347 | — | 67.2 | — | 2104 |
-
 ### mlx-community/Qwen3-4B-4bit  (Mac M4 Max, sustained-generation)
 
 | Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
 |---|---|---|---:|---:|---:|---:|---:|---:|---:|
 | mlx-swift | `mlx-community/Qwen3-4B-4bit` | Q4 | 1 | 0.6 | 49 | 507.8 | 151.1 | — | 2738 |
-
-### mlx-community/Qwen3-8B-4bit  (Mac M4 Max, sustained-generation)
-
-| Runtime | Model ID | Quant | n | Load (s, median) | TTFT (ms, median) | Prefill tok/s (median) | Decode cold (median) | Decode warm (r2-4 med) | Peak Mem (MB, median) |
-|---|---|---|---:|---:|---:|---:|---:|---:|---:|
-| mlx-swift | `mlx-community/Qwen3-8B-4bit` | Q4 | 1 | 0.6 | 73 | 331.0 | 93.2 | — | 4977 |
 
 ## Pivot 2 — by runtime
 

--- a/scripts/bench_common.py
+++ b/scripts/bench_common.py
@@ -57,6 +57,7 @@ LOGICAL_MODELS: list[tuple[str, str]] = [
     ("qwen3.5-2b",      "Qwen 3.5 2B"),
     ("qwen3.5-0.8b",    "Qwen 3.5 0.8B"),
     # Qwen 3
+    ("qwen3-8b",        "Qwen 3 8B"),
     ("qwen3-1.7b",      "Qwen 3 1.7B"),
     ("qwen3-0.6b",      "Qwen 3 0.6B"),
     # Qwen 2.5

--- a/scripts/render_headline.py
+++ b/scripts/render_headline.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Render the README headline decode table from stored records.
+
+  python3 scripts/render_headline.py          # rewrite the generated block in README.md
+  python3 scripts/render_headline.py --check  # CI: fail if stale
+
+Why: the headline table used to be typed by hand and drifted from the body and
+from results/ — on 2026-09-04 an iPhone row copied from a stale local README
+re-published a retracted MLX number next to a Core AI number from a different
+session. The top of the README is the part that gets quoted, so it is now a
+projection of stored records, like LEADERBOARD.md. Hand edits inside the
+markers are overwritten.
+
+Sources (read-only):
+  results/summary/device-runs.csv   harness short-chat cells. The per-cell numbers come
+                                    from render_leaderboard's latest_session / arm_row,
+                                    so a number shown in both places is the same number.
+  results/hybrid/*.json             the CLI hybrid-model reports (llama-bench / mlx_lm).
+
+Rules applied as code (slugs: methodology/fairness-rules.md):
+  cold-warm-split      warm median where the session has warm runs, else the cold
+                       number tagged "cold"; never pooled.
+  thermal guard (§2)   only runs that STARTED thermal-nominal count — the same filter
+                       regression_diff.py applies. A session whose runs all started
+                       hot is skipped and the cell falls back to its newest nominal
+                       session (results/raw/2026-08-26-iphone-coreai-pairs is
+                       THERMAL_FAIL on every cell by its own gate file; it must not
+                       become the headline).
+  iphone-session-variance
+                       every cell carries its capture date; a row whose cells come
+                       from different sessions gets an automatic note, and no ratio
+                       is printed anywhere in the block.
+  quant-per-arm-rule   the recipe (artifact, quantization, engine, n) of every cell
+                       is listed right under the table.
+  stored-report-rule   a number with no record under results/ does not appear. Known
+                       gaps: the M4 Max Core AI `llm-benchmark` runs (no parser yet)
+                       and the hybrid-model Core AI cells (HF cards only).
+  no-cherry-pick       every artifact of a runtime is shown, fastest first; spread
+                       over SPREAD_FLAG carries the same ⚠ as LEADERBOARD.md.
+
+HEADLINE_MODELS selects WHICH harness rows appear (this is a headline, not the
+standings — LEADERBOARD.md is that); it never selects numbers.
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bench_common import DEVICE_DISPLAY, logical_model  # noqa: E402
+from render_leaderboard import SPREAD_FLAG, arm_row, fmt, latest_session, load  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+HYBRID = os.path.join(ROOT, "results", "hybrid")
+TARGET = os.path.join(ROOT, "README.md")
+BEGIN = "<!-- BEGIN GENERATED: scripts/render_headline.py -->"
+END = "<!-- END GENERATED: scripts/render_headline.py -->"
+HEADLINE_TASK = "short-chat"
+
+# Logical names from bench_common.LOGICAL_MODELS. Order = table order.
+HEADLINE_MODELS = ["Qwen 3 0.6B", "Qwen 3 8B"]
+PLATFORMS = ("ios", "mac")  # Android standings: LEADERBOARD.md
+RUNTIME_LABEL = {
+    "core-ai": "Apple Core AI",
+    "mlx-swift": "MLX",
+    "llama.cpp": "llama.cpp",
+    "litert-lm": "LiteRT-LM",
+    "coreml-llm": "Core ML",
+}
+RUNTIME_ORDER = list(RUNTIME_LABEL)
+# fairness-rules §2 thermal guard, same states as regression_diff.NOMINAL_STATES:
+# rows with no thermal field (pre-thermal writers, Mac CLI) pass through.
+NOMINAL_STATES = ("nominal", "")
+SUPERSCRIPTS = "¹²³⁴⁵⁶⁷⁸⁹"
+
+
+def device_name(model_identifier):
+    return DEVICE_DISPLAY.get(model_identifier, model_identifier)
+
+
+def session_key(rows):
+    """Campaign dir (one sitting) or the date for legacy flat rows — the same
+    session notion render_leaderboard.latest_session uses."""
+    r = rows[0]
+    return r["campaign"] if r["campaign"] and r["campaign"] != "flat" else (r["timestamp"] or "")[:10]
+
+
+# ----------------------------------------------------------------------------
+# harness cells
+# ----------------------------------------------------------------------------
+
+def harness_rows():
+    """(platform, device, model) -> runtime -> [(arm dict, model_id, session)]"""
+    tree = {}
+    hot_only = []  # arms with no nominal-thermal capture at all (failed-runs-stay)
+    cells = {}
+    for r in load("device-runs.csv"):
+        if r["task"] != HEADLINE_TASK or not r["model_id"] or not r["device"]:
+            continue
+        if (r.get("platform") or "") not in PLATFORMS:
+            continue
+        model = logical_model(r["model_id"])
+        if model not in HEADLINE_MODELS:
+            continue
+        cells.setdefault((r["platform"], r["device"], model, r["runtime"], r["model_id"]), []).append(r)
+    for (plat, dev, model, rt, mid), rows in cells.items():
+        ok = [r for r in rows if (r.get("thermal_initial") or "") in NOMINAL_STATES]
+        if not ok:
+            hot_only.append((plat, dev, model, rt, mid, arm_row(rows)["date"]))
+            continue
+        a = arm_row(ok)
+        sess, _ = latest_session(ok)  # the session arm_row used, for the note
+        # hot-start captures newer than the session shown: named, so the reader
+        # can see why LEADERBOARD.md (no thermal gate yet) may show a later date
+        skipped = sorted({(r["timestamp"] or "")[:10] for r in rows
+                          if r not in ok and (r["timestamp"] or "")[:10] > a["date"]})
+        tree.setdefault((plat, dev, model), {}).setdefault(rt, []).append(
+            (a, mid, session_key(sess), skipped))
+    return tree, hot_only
+
+
+def cell_text(arms):
+    parts = []
+    multi = len(arms) > 1
+    for a, mid, _sess, _skipped in sorted(arms, key=lambda t: -(t[0]["warm"] or t[0]["cold"] or 0)):
+        if a["warm"] is not None:
+            txt = f"**{fmt(a['warm'])}**"
+            if a["spread"] > SPREAD_FLAG:
+                txt += f" ⚠spread {a['spread']:.0f}%"
+        elif a["cold"] is not None:
+            txt = f"{fmt(a['cold'])} cold"
+        else:
+            txt = "—"
+        if multi:
+            txt += f" `{mid.split('/')[-1]}`"
+        txt += f" ({a['date']})"
+        parts.append(txt)
+    return "<br>".join(parts) if parts else "—"
+
+
+def recipe_line(dev, model, rt, a, mid, sess, skipped):
+    if a["warm"] is not None:
+        basis = f"warm median of {a['warm_n']} in-process runs"
+    else:
+        n = a["n"]
+        basis = (f"cold, {n} fresh-process launch{'es' if n != 1 else ''} in that session "
+                 "(no warm runs), last one shown")
+    where = f"session {a['date']}" + (f" (`{os.path.basename(sess)}`)" if sess != a["date"] else "")
+    line = (f"- {dev} · {model} · {RUNTIME_LABEL.get(rt, rt)}: `{mid}` — {a['quant']}, "
+            f"engine {a['engine']}, {basis}, {where}")
+    if skipped:
+        line += (f"; newer capture{'s' if len(skipped) > 1 else ''} on {', '.join(skipped)} "
+                 "started hot and did not qualify (thermal guard)")
+    return line
+
+
+def render_harness(lines):
+    tree, hot_only = harness_rows()
+    runtimes = [rt for rt in RUNTIME_ORDER
+                if any(rt in arms for arms in tree.values())]
+    runtimes += sorted({rt for arms in tree.values() for rt in arms} - set(runtimes))
+    order = {p: i for i, p in enumerate(PLATFORMS)}
+    keys = sorted(tree, key=lambda k: (order[k[0]], k[1], HEADLINE_MODELS.index(k[2])))
+
+    lines.append(
+        f"**Harness cells** — task `{HEADLINE_TASK}` (same prompt and 128-token budget "
+        "for every arm, in-tree harness, per-run JSONL under `results/raw/`). "
+        "**Bold** = warm, the median of one session's in-process runs (run 1 of every "
+        "launch dropped as cold); \"cold\" = fresh-process first generation, shown where "
+        "a session has no warm runs. Only runs that started thermal-nominal count "
+        "([fairness-rules §2](methodology/fairness-rules.md)), and each cell is its newest "
+        "qualifying session — the date in parentheses. Several artifacts of one runtime "
+        "are listed fastest-first, never pooled.")
+    lines.append("")
+    lines.append("| Model | Device | " + " | ".join(RUNTIME_LABEL.get(rt, rt) for rt in runtimes) + " |")
+    lines.append("|---|---|" + "|".join("---:" for _ in runtimes) + "|")
+    notes, recipes = [], []
+    latest = ""
+    for key in keys:
+        plat, dev, model = key
+        arms = tree[key]
+        sessions = {}   # session -> set(runtime label)
+        by_rt = {}      # runtime label -> ["date (campaign)", ...]
+        for rt in runtimes:
+            for a, mid, sess, skipped in arms.get(rt, []):
+                label = RUNTIME_LABEL.get(rt, rt)
+                sessions.setdefault(sess, set()).add(label)
+                shown = a["date"] + (f" (`{os.path.basename(sess)}`)" if sess != a["date"] else "")
+                if shown not in by_rt.setdefault(label, []):
+                    by_rt[label].append(shown)
+                latest = max(latest, a["date"])
+                recipes.append(recipe_line(device_name(dev), model, rt, a, mid, sess, skipped))
+        marker = ""
+        if len(sessions) > 1:
+            marker = " " + SUPERSCRIPTS[len(notes) % len(SUPERSCRIPTS)]
+            by = "; ".join(f"{label} {' and '.join(dates)}" for label, dates in by_rt.items())
+            notes.append(
+                f"{marker.strip()} {model} · {device_name(dev)}: the cells come from "
+                f"{len(sessions)} capture sessions ({by}). Same device, different sittings — "
+                "device state moved between sessions on this phone "
+                "(`results/raw/2026-07-13-mlx-variance/`), so a ratio between two cells of "
+                "this row is not a measurement; compare within one session (the Core AI "
+                "section below carries the per-session tables).")
+        cells = [cell_text(arms[rt]) if rt in arms else "—" for rt in runtimes]
+        lines.append(f"| {model}{marker} | {device_name(dev)} | " + " | ".join(cells) + " |")
+    lines.append("")
+    for n in notes:
+        lines.append(n)
+        lines.append("")
+    if hot_only:
+        lines.append("Arms with no thermal-nominal capture (failed-runs-stay; the hot captures "
+                     "are in `results/raw/` and LEADERBOARD.md):")
+        lines.append("")
+        for plat, dev, model, rt, mid, date in sorted(hot_only):
+            lines.append(f"- {device_name(dev)} · {model} · {RUNTIME_LABEL.get(rt, rt)}: "
+                         f"`{mid}` — newest capture {date} started hot")
+        lines.append("")
+    lines.append("<details><summary>Recipes behind the harness cells (quant-per-arm-rule)</summary>")
+    lines.append("")
+    lines.extend(recipes)
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+    return latest
+
+
+# ----------------------------------------------------------------------------
+# hybrid CLI reports
+# ----------------------------------------------------------------------------
+
+def _num(entry, *keys):
+    """Pull the decode number out of the two report shapes."""
+    d = entry
+    for k in keys:
+        if d is None:
+            return None
+        d = d.get(k)
+    return d
+
+
+def hybrid_rows():
+    """[(model, device, date, {runtime: (value, recipe, caveat)}, source)]"""
+    out = []
+    for path in sorted(glob.glob(os.path.join(HYBRID, "*.json"))):
+        d = json.load(open(path))
+        src = os.path.relpath(path, ROOT)
+        if "results" in d:  # nemotron3-nano shape: one entry per (model, stack)
+            device = d.get("hardware", {}).get("cpu", "?")
+            date = d.get("date", "")
+            rows = {}
+            for e in d["results"] + d.get("granite_4_0_h_tiny", []):
+                stack = e["stack"]
+                rt = "llama.cpp" if stack.startswith("llama.cpp") else "mlx-swift" if stack.startswith("MLX") else stack
+                dec = e["decode_tps"]
+                val = dec.get("median", dec.get("mean"))
+                basis = (f"{dec.get('test')}, median of {len(dec['runs'])} processes" if "runs" in dec
+                         else f"{dec.get('test')} mean of 3 (±{dec.get('std'):.2f})")
+                recipe = f"{e['repo']} {e['quant']} ({e.get('stack_version', stack)}; {basis})"
+                rows.setdefault(e["model"], {})[rt] = (val, recipe, None)
+            for model, arms in rows.items():
+                out.append((model, device, date, arms, src))
+        elif "rows" in d:  # hybrid-apple-silicon-bench-2 shape: one entry per model
+            device = re.sub(r"\s+\d+\s*GiB$", "", d.get("machine", "?").split(",")[0])
+            date = d.get("measured", "")
+            lc = d.get("llama_cpp", {})
+            mx = d.get("mlx", {})
+            for e in d["rows"]:
+                arms = {}
+                l = e.get("llama_cpp")
+                if l:
+                    arms["llama.cpp"] = (
+                        l["tg256"]["avg_ts"],
+                        f"{l['weights']} (llama.cpp build {lc.get('build')} {lc.get('source', '')}; "
+                        f"tg256 mean of 3 (±{l['tg256']['stddev_ts']:.2f}))",
+                        None)
+                m = e.get("mlx")
+                if m:
+                    arms["mlx-swift"] = (
+                        m["median_gen_tps"],
+                        f"{m['weights']} (mlx {mx.get('mlx')}, mlx-lm {mx.get('mlx_lm')}; "
+                        f"256-token generation, median of {len(m['runs'])} processes)",
+                        m.get("coherence"))
+                out.append((e["model"], device, date, arms, src))
+    return out
+
+
+def render_hybrid(lines):
+    rows = sorted(hybrid_rows(), key=lambda r: r[2])  # stable: report date, then file order
+    if not rows:
+        return ""
+    runtimes = [rt for rt in RUNTIME_ORDER if any(rt in r[3] for r in rows)]
+    lines.append(
+        "**Hybrid Mamba-2 / Transformer models, CLI runs** — llama.cpp = `llama-bench` "
+        "tg256 (pp512 prompt), MLX = `mlx_lm generate` 256 tokens; greedy, batch 1, mains "
+        "power, one machine. Quantization is **not** equal across columns (Q4_K_M is not "
+        "4-bit affine — see the recipes and the caveats in each report); ‡ = the report "
+        "records a coherence problem with that output. Reports: " +
+        ", ".join(f"`{s}`" for s in sorted({r[4] for r in rows})) + ".")
+    lines.append("")
+    lines.append("| Model | Device | " + " | ".join(RUNTIME_LABEL.get(rt, rt) for rt in runtimes) + " | Measured |")
+    lines.append("|---|---|" + "|".join("---:" for _ in runtimes) + "|---|")
+    recipes = []
+    latest = ""
+    for model, device, date, arms, src in rows:
+        latest = max(latest, date)
+        cells = []
+        for rt in runtimes:
+            if rt not in arms:
+                cells.append("—")
+                continue
+            val, recipe, caveat = arms[rt]
+            cells.append(f"{val:.1f}" + (" ‡" if caveat else ""))
+            recipes.append(f"- {model} · {RUNTIME_LABEL.get(rt, rt)}: {recipe}"
+                           + (f" — ‡ {caveat}" if caveat else ""))
+        lines.append(f"| {model} | {device} | " + " | ".join(cells) + f" | {date} |")
+    lines.append("")
+    lines.append("<details><summary>Recipes behind the hybrid cells</summary>")
+    lines.append("")
+    lines.extend(recipes)
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+    return latest
+
+
+# ----------------------------------------------------------------------------
+
+def generate():
+    body = []
+    latest_h = render_harness(body)
+    latest_x = render_hybrid(body)
+    latest = max(latest_h, latest_x)
+    head = [
+        BEGIN,
+        "",
+        "**Decode tok/s, batch 1, greedy.** Generated from stored records by "
+        f"`scripts/render_headline.py` (newest record {latest or 'n/a'}) — do not edit "
+        "inside the markers. Full standings with prefill, TTFT, memory and GSM8K: "
+        "[LEADERBOARD.md](LEADERBOARD.md); every capture: [RESULTS.md](RESULTS.md) and "
+        "`results/`. No cross-cell ratios are printed here on purpose: cells are "
+        "compared only within one session, and the session is part of every cell.",
+        "",
+    ]
+    return "\n".join(head + body + [END]) + "\n"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--check", action="store_true")
+    args = ap.parse_args()
+    block = generate()
+    current = open(TARGET).read()
+    if BEGIN not in current or END not in current:
+        print(f"README.md has no {BEGIN} / {END} markers — add them where the "
+              "headline table goes", file=sys.stderr)
+        return 2
+    head, _, rest = current.partition(BEGIN)
+    _, _, tail = rest.partition(END)
+    new = head + block.rstrip("\n") + tail  # text after END is kept verbatim
+    if args.check:
+        if current != new:
+            print("README.md headline block is stale — run scripts/render_headline.py",
+                  file=sys.stderr)
+            return 1
+        print("README.md headline block is up to date.")
+        return 0
+    open(TARGET, "w").write(new)
+    print(f"wrote {os.path.relpath(TARGET, ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

The headline table at the top of README (#3) was typed by hand from a local README 86 commits behind origin. Its iPhone Qwen3-0.6B row said Core AI **181** / MLX **112**. The body had retracted MLX 112 on 2026-07-13 as a Debug-build contamination, and the two numbers came from different sessions. The top of the README is what gets quoted, so it must not disagree with the body or with `results/`.

## What

- **`scripts/render_headline.py`** writes the block between `<!-- BEGIN/END GENERATED: scripts/render_headline.py -->` from stored records, the way `render_leaderboard.py` does for LEADERBOARD.md. `--check` exits 1 when the block is stale. A new CI job (`headline-check`) runs it, and README.md joins the PR path filter.
  - Harness cells come from `results/summary/device-runs.csv` through `render_leaderboard`'s `latest_session` / `arm_row`, so a number shown in both files is the same number. The fairness §2 thermal guard applies: only runs that started thermal-nominal count (the states `regression_diff.NOMINAL_STATES` uses). A session whose runs all started hot falls back to the newest nominal session, and the recipe line names the skipped capture.
  - Hybrid-model cells come from `results/hybrid/*.json` (both report shapes).
  - Every cell carries its capture date. A row whose cells come from different sessions gets an automatic note. The recipe of every cell (artifact, quantization, engine, n) sits under the table. No cross-cell ratio is printed.
  - `HEADLINE_MODELS` selects which harness rows appear; it never selects numbers.
- **Cells with no in-repo record are not generated** (stored-report-rule): the M4 Max Core AI `llm-benchmark` runs (no parser for that format yet) and the hybrid-model Core AI numbers (HF cards only). A pointer paragraph outside the markers links to them.
- `bench_common`: the two Qwen3-8B ids pool as "Qwen 3 8B"; LEADERBOARD.md and RESULTS.md regroup accordingly.
- LEADERBOARD.md re-rendered. It had been stale on main since 2026-08-27 (⚠spread markers, Android budget note), which is why the data-pipeline workflow was red.

## The generated iPhone row

| Runtime | Cell | Session |
|---|---|---|
| Apple Core AI | 193.3 cold (`qwen3-0.6b-gpu`); 122.4 / 116.9 warm (ANE artifacts) | 2026-06-18; 2026-07-13 |
| MLX | 178.8 warm | 2026-08-26 |
| LiteRT-LM | 122.1 warm | 2026-08-26 |
| Core ML | 37.7 cold | 2026-06-17 |

The row carries the "5 sessions, do not ratio" note automatically. The 2026-08-26 `iphone-coreai-pairs` session (Core AI GPU 147.4 warm) is THERMAL_FAIL on every cell by its own gate file, so it does not qualify; the recipe line names it. LEADERBOARD.md has no thermal gate yet and still shows that capture (follow-up below).

## Checks

All seven workflow jobs reproduced locally: `render_results.py --check`, `validate_cells.py` (both), `build_summary.py` + `git diff --exit-code results/summary/`, `render_leaderboard.py --check`, `render_headline.py --check`, `py_compile` + `bash -n`, `generate_charts.py`.

## Follow-ups (not in this PR)

- Apply the §2 thermal guard in `render_leaderboard.py` too (measured: 15 cells change, 4 drop), so both generated surfaces use one policy.
- Parse the `llm-benchmark` JSONs under `results/raw/2026-06-11-m4max-coreai-matrix/` so the Mac Core AI cells return under their own protocol label.
- Body text older than the records: the Core AI section's "warm re-capture is blocked" (a warm capture exists from 2026-08-26, thermal-fair) and the Core ML "39" cold cell (records: 37.7, nominal short-chat).
