### PR TITLE
Thermal guard in the leaderboard; Mac Core AI llm-benchmark cells in the headline; body text caught up with records

### DIFF
--- a/LEADERBOARD.md
+++ b/LEADERBOARD.md
@@ -12,7 +12,7 @@ Generated from `results/summary/*.csv` (latest capture 2026-08-26) by `scripts/r
 
 Headline task: **short-chat**, warm = median of same-session warm runs (cold-warm-split); other tasks and full history: RESULTS.md. Rows sort by warm decode; the recipe (quantization, engine build) is part of every row — a faster number under a different recipe is a different deployment profile, not a win.
 
-† = quantization label carries the audited in-place correction (Gemma-4 `.litertlm` is the wNa8o8 mobile schema; early rows recorded "INT4 (QAT)" — quant-label-rule). mem MB = phys_footprint on Apple rows, RSS on Android rows (no footprint equivalent; methodology/android.md).
+† = quantization label carries the audited in-place correction (Gemma-4 `.litertlm` is the wNa8o8 mobile schema; early rows recorded "INT4 (QAT)" — quant-label-rule). mem MB = phys_footprint on Apple rows, RSS on Android rows (no footprint equivalent; methodology/android.md). Only runs that started thermal-nominal count (fairness-rules §2): each cell is its newest nominal-start session; ⚠hot marks a cell whose every capture started hot, kept in the table with its numbers (failed-runs-stay).
 
 ## mac
 
@@ -152,7 +152,7 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 
 | runtime | artifact | quant | engine | warm tok/s | cold tok/s | prefill tok/s | TTFT ms | mem MB | GSM8K | captured |
 |---|---|---|---|---|---|---|---|---|---|---|
-| litert-lm | `litert-community/gemma-4-E2B-it-litert-lm` | wNa8o8 (int2/int4/int8 + int8 activations, QAT) | v0.16.0 | 51.0 ⚠spread 21% | 55.4 | 408.7 | 80.5 | 479.7 | — | 2026-08-19 |
+| litert-lm | `litert-community/gemma-4-E2B-it-litert-lm` | wNa8o8 (int2/int4/int8 + int8 activations, QAT) | v0.16.0 | 50.7 ⚠spread 19% | 55.4 | 382.1 | 81.0 | 477.0 | — | 2026-08-19 |
 | mlx-swift | `mlx-community/gemma-4-e2b-it-4bit` | Q4 | pre-stamp | 47.8 | 44.1 | 183.6 | 218.5 | 2999.8 | — | 2026-07-30 |
 | llama.cpp | `unsloth/gemma-4-E2B-it-GGUF/Q4_K_M` | Q4_K_M | pre-stamp | 38.9 | 38.5 | 1710.5 | 108.0 | 198.6 | — | 2026-07-30 |
 | core-ai | `core-ai/gemma4-e2b-gpu` | int4 q4_0 (QAT transplant) | pre-stamp | — | 46.9 | 23.5 | 3133.0 | 455.3 | — | 2026-07-30 |
@@ -162,11 +162,11 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | runtime | artifact | quant | engine | warm tok/s | cold tok/s | prefill tok/s | TTFT ms | mem MB | GSM8K | captured |
 |---|---|---|---|---|---|---|---|---|---|---|
 | mlx-swift | `mlx-community/Qwen3-0.6B-4bit` | Q4 | 60bd0d7880c82980f9481f8be78862e9b63c58a3 | 178.8 | 178.7 | 533.6 | 37.0 | 488.2 | — | 2026-08-26 |
-| core-ai | `core-ai/qwen3-0.6b-gpu` | INT4 (dynamic, macOS-26-era export) | 0.2.0+static-inputs-patch | 147.4 | 152.3 | 954.1 | 23.0 | 180.2 | — | 2026-08-26 |
 | core-ai | `core-ai/qwen3-0.6b-ane-june` | mixed 4/8-bit (June static export) | pre-stamp | 122.4 | 124.9 | 675.6 | 29.0 | — | — | 2026-07-13 |
-| litert-lm | `litert-community/Qwen3-0.6B` | INT4 (mixed, blockwise gs32) | v0.16.0 | 121.6 | 120.6 | 183.9 | 151.5 | 465.4 | — | 2026-08-26 |
+| litert-lm | `litert-community/Qwen3-0.6B` | INT4 (mixed, blockwise gs32) | v0.16.0 | 122.1 | 123.8 | 182.5 | 149.0 | 470.8 | — | 2026-08-26 |
 | core-ai | `core-ai/qwen3-0.6b-ane` | 4-bit palettized (uniform g32) | pre-stamp | 116.9 | 118.7 | 697.3 | 28.5 | — | — | 2026-07-13 |
-| coreml-llm | `coreml-llm/qwen3-0.6b` | INT8 palettized | pre-stamp | — | 37.8 | 33.2 | 572.0 | — | — | 2026-06-17 |
+| coreml-llm | `coreml-llm/qwen3-0.6b` | INT8 palettized | pre-stamp | — | 37.7 | 33.2 | 572.0 | — | — | 2026-06-17 |
+| core-ai | `core-ai/qwen3-0.6b-gpu` | INT4 (dynamic) | pre-stamp | — | 193.3 | 1699.9 | 16.0 | — | — | 2026-06-18 |
 
 **Qwen 3 1.7B**
 
@@ -175,7 +175,7 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | core-ai | `core-ai/qwen3-1.7b-gpu-june` | INT4 (dynamic, June export) | pre-stamp | 67.6 | 67.9 | 457.6 | 45.0 | — | — | 2026-07-13 |
 | mlx-swift | `mlx-community/Qwen3-1.7B-4bit` | Q4 | pre-stamp | 65.1 | 63.9 | 248.6 | 77.5 | — | — | 2026-07-13 |
 | litert-lm | `litert-local/qwen3-1.7b-int4` | INT4 (mixed, int8 embed) | pre-stamp | 49.3 | 46.8 | — | 855.5 | — | — | 2026-07-13 |
-| litert-lm | `litert-local/qwen3-1.7b` | INT8 (dynamic, ekv1024) | pre-stamp | — | 30.2 | — | 453.0 | — | — | 2026-06-19 |
+| litert-lm | `litert-local/qwen3-1.7b` | INT8 (dynamic, ekv1024) | pre-stamp | — | 30.2 | — | 453.0 | — | — | 2026-06-19 ⚠hot |
 | core-ai | `core-ai/qwen3-1.7b-gpu` | INT4 (dynamic) | pre-stamp | — | 64.7 | 763.6 | 31.0 | — | — | 2026-07-14 |
 
 **Qwen 3.5 2B**
@@ -184,7 +184,7 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 |---|---|---|---|---|---|---|---|---|---|---|
 | mlx-swift | `mlx-community/Qwen3.5-2B-MLX-4bit` | Q4 | pre-stamp | — | 61.2 | 249.3 | 103.0 | — | — | 2026-05-27 |
 | llama.cpp | `unsloth/Qwen3.5-2B-GGUF/Q4_K_M` | Q4_K_M | pre-stamp | — | 38.7 | 2503.9 | 96.0 | — | — | 2026-05-27 |
-| coreml-llm | `coreml-llm/qwen3.5-2b` | INT8 | pre-stamp | — | 28.1 | 27.3 | 844.0 | — | — | 2026-05-28 |
+| coreml-llm | `coreml-llm/qwen3.5-2b` | INT8 | pre-stamp | — | 28.1 | 27.3 | 844.0 | — | — | 2026-05-28 ⚠hot |
 
 **SmolLM 3B**
 
@@ -207,25 +207,25 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | core-ai/gemma3-1b-gpu | core-ai | `core-ai/gemma3-1b-gpu` | INT4 (dynamic) | pre-stamp | — | 94.3 | 2026-07-14 |
 | core-ai/lfm2.5-1.2b-gpu | core-ai | `core-ai/lfm2.5-1.2b-gpu` | int8hu block32 sym (untied head) | 0.2.0+static-inputs-patch | 45.5 | 45.7 | 2026-08-26 |
 | core-ai/llama-3.2-3b-ane | core-ai | `core-ai/llama-3.2-3b-ane` | 4-bit palettized (uniform g32) | pre-stamp | 38.0 | — | 2026-07-13 |
-| core-ai/llama-3.2-3b-gpu | core-ai | `core-ai/llama-3.2-3b-gpu` | INT4 (dynamic) | pre-stamp | — | 35.5 | 2026-07-14 |
-| core-ai/minicpm5-1b-gpu | core-ai | `core-ai/minicpm5-1b-gpu` | INT8 (sym, dynamic) | 0.2.0+static-inputs-patch | 72.1 | 72.2 | 2026-08-26 |
+| core-ai/llama-3.2-3b-gpu | core-ai | `core-ai/llama-3.2-3b-gpu` | INT4 (dynamic) | pre-stamp | 34.8 | — | 2026-07-13 |
+| core-ai/minicpm5-1b-gpu | core-ai | `core-ai/minicpm5-1b-gpu` | INT8 (sym, dynamic) | 0.2.0+static-inputs-patch | 72.1 | 72.2 | 2026-08-26 ⚠hot |
 | core-ai/ministral-3b-gpu | core-ai | `core-ai/ministral-3b-gpu` | INT4 (dynamic) | pre-stamp | — | 29.3 | 2026-07-14 |
 | core-ai/olmo2-1b-ane | core-ai | `core-ai/olmo2-1b-ane` | 4-bit palettized (uniform g32) | pre-stamp | — | 96.3 | 2026-07-14 |
 | core-ai/olmo2-1b-gpu | core-ai | `core-ai/olmo2-1b-gpu` | INT4 (dynamic) | pre-stamp | — | 92.5 | 2026-07-14 |
-| core-ai/qwen3-4b-ane | core-ai | `core-ai/qwen3-4b-ane` | 4-bit palettized (uniform g32) | pre-stamp | 30.0 ⚠spread 9% | 27.0 | 2026-07-13 |
+| core-ai/qwen3-4b-ane | core-ai | `core-ai/qwen3-4b-ane` | 4-bit palettized (uniform g32) | pre-stamp | 30.0 ⚠spread 9% | 27.0 | 2026-07-13 ⚠hot |
 | core-ai/qwen3-4b-gpu | core-ai | `core-ai/qwen3-4b-gpu` | INT4 (dynamic) | pre-stamp | 26.4 | 27.0 | 2026-07-13 |
 | core-ai/tinyswallow-1.5b-ane | core-ai | `core-ai/tinyswallow-1.5b-ane` | 4-bit palettized (uniform g32) | pre-stamp | — | 72.9 | 2026-07-14 |
 | core-ai/tinyswallow-1.5b-gpu | core-ai | `core-ai/tinyswallow-1.5b-gpu` | INT4 (dynamic) | pre-stamp | — | 69.7 | 2026-07-14 |
 | core-ai/vibethinker-1.5b-ane | core-ai | `core-ai/vibethinker-1.5b-ane` | 4-bit palettized (uniform g32) | pre-stamp | 73.8 | 73.4 | 2026-07-13 |
 | core-ai/vibethinker-1.5b-gpu | core-ai | `core-ai/vibethinker-1.5b-gpu` | INT4 (dynamic) | pre-stamp | — | 71.0 | 2026-07-14 |
-| litert-community/DeepSeek-R1-Distill-Qwen-1.5B | litert-lm | `litert-community/DeepSeek-R1-Distill-Qwen-1.5B` | INT8 | v0.16.0 | 26.7 ⚠spread 19% | 31.2 | 2026-08-24 |
+| litert-community/DeepSeek-R1-Distill-Qwen-1.5B | litert-lm | `litert-community/DeepSeek-R1-Distill-Qwen-1.5B` | INT8 | v0.16.0 | 29.2 | 31.2 | 2026-08-24 |
 | litert-community/Gemma3-1B-IT | litert-lm | `litert-community/Gemma3-1B-IT` | INT4 | pre-stamp | 72.1 | 72.7 | 2026-07-13 |
 | litert-community/LFM2.5-1.2B-Instruct | litert-lm | `litert-community/LFM2.5-1.2B-Instruct` | int4_gpu (litert-community descriptor) | v0.16.0 | 69.5 | 69.9 | 2026-08-26 |
-| litert-community/MiniCPM5-1B | litert-lm | `litert-community/MiniCPM5-1B` | wi4b32_wi8_afp32 (gpu-opt) | v0.16.0 | 34.2 ⚠spread 14% | 36.2 | 2026-08-26 |
-| litert-community/Phi-4-mini-instruct | litert-lm | `litert-community/Phi-4-mini-instruct` | INT8 | pre-stamp | 11.6 ⚠spread 7% | 11.4 | 2026-07-24 |
-| litert-community/Qwen3-4B | litert-lm | `litert-community/Qwen3-4B` | INT4 (mixed, blockwise gs32) | v0.16.0 | 16.1 ⚠spread 60% | 23.1 | 2026-08-19 |
+| litert-community/MiniCPM5-1B | litert-lm | `litert-community/MiniCPM5-1B` | wi4b32_wi8_afp32 (gpu-opt) | v0.16.0 | 35.5 | 34.9 | 2026-08-24 |
+| litert-community/Phi-4-mini-instruct | litert-lm | `litert-community/Phi-4-mini-instruct` | INT8 | pre-stamp | 11.0 | 11.1 | 2026-07-13 |
+| litert-community/Qwen3-4B | litert-lm | `litert-community/Qwen3-4B` | INT4 (mixed, blockwise gs32) | v0.16.0 | 18.5 | 23.1 | 2026-08-19 |
 | litert-community/TinySwallow-1.5B-Instruct | litert-lm | `litert-community/TinySwallow-1.5B-Instruct` | INT8 | pre-stamp | 29.4 ⚠spread 10% | 29.2 | 2026-07-23 |
-| litert-community/VibeThinker-1.5B | litert-lm | `litert-community/VibeThinker-1.5B` | INT8 | pre-stamp | 29.3 ⚠spread 22% | 30.6 | 2026-07-23 |
+| litert-community/VibeThinker-1.5B | litert-lm | `litert-community/VibeThinker-1.5B` | INT8 | pre-stamp | 30.0 | 30.6 | 2026-07-23 |
 | litert-local/llama32-3b | litert-lm | `litert-local/llama32-3b` | INT4 | pre-stamp | 18.2 ⚠spread 9% | 19.2 | 2026-07-13 |
 | litert-local/ministral3-3b | litert-lm | `litert-local/ministral3-3b` | INT4 | pre-stamp | 18.4 ⚠spread 14% | 19.0 | 2026-07-14 |
 | litert-local/olmo2-1b | litert-lm | `litert-local/olmo2-1b` | INT4 | pre-stamp | 20.6 ⚠spread 25% | 26.4 | 2026-07-13 |
@@ -234,10 +234,10 @@ Headline task: **short-chat**, warm = median of same-session warm runs (cold-war
 | mlx-community/Phi-4-mini-instruct-4bit | mlx-swift | `mlx-community/Phi-4-mini-instruct-4bit` | Q4 | pre-stamp | 29.3 | 29.5 | 2026-07-13 |
 | mlx-community/Qwen3-4B-4bit | mlx-swift | `mlx-community/Qwen3-4B-4bit` | Q4 | pre-stamp | 28.0 | 28.4 | 2026-07-13 |
 | mlx-community/TinySwallow-1.5B-Instruct-4bit | mlx-swift | `mlx-community/TinySwallow-1.5B-Instruct-4bit` | Q4 | pre-stamp | 72.9 | 72.6 | 2026-07-13 |
-| own/DeepSeek-R1-1.5B-int4-BOCTAV4 | litert-lm | `own/DeepSeek-R1-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 44.5 ⚠spread 8% | 45.8 | 2026-07-24 |
-| own/Phi-4-mini-int4-BOCTAV4-128 | litert-lm | `own/Phi-4-mini-int4-BOCTAV4-128` | INT4 (BOCTAV4 blockwise-128 OCTAV, int8 embed, static-rope) | pre-stamp | 17.5 | 17.6 | 2026-07-24 |
+| own/DeepSeek-R1-1.5B-int4-BOCTAV4 | litert-lm | `own/DeepSeek-R1-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 45.5 ⚠spread 10% | 47.6 | 2026-07-20 |
+| own/Phi-4-mini-int4-BOCTAV4-128 | litert-lm | `own/Phi-4-mini-int4-BOCTAV4-128` | INT4 (BOCTAV4 blockwise-128 OCTAV, int8 embed, static-rope) | pre-stamp | 17.4 | 17.0 | 2026-07-20 |
 | own/TinySwallow-1.5B-int4-BOCTAV4 | litert-lm | `own/TinySwallow-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 45.6 ⚠spread 7% | 46.8 | 2026-07-23 |
-| own/VibeThinker-1.5B-int4-BOCTAV4 | litert-lm | `own/VibeThinker-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 45.7 ⚠spread 8% | 46.8 | 2026-07-23 |
+| own/VibeThinker-1.5B-int4-BOCTAV4 | litert-lm | `own/VibeThinker-1.5B-int4-BOCTAV4` | INT4 (BOCTAV4 blockwise-32 OCTAV, int8 embed) | pre-stamp | 46.1 | 46.8 | 2026-07-23 |
 
 </details>
 
@@ -297,8 +297,8 @@ Android decode spans are not budget-matched across arms: llama-cli caps at the 1
 
 | runtime | artifact | quant | engine | warm tok/s | cold tok/s | prefill tok/s | TTFT ms | mem MB | GSM8K | captured |
 |---|---|---|---|---|---|---|---|---|---|---|
-| litert-lm-gpu | `litert-community/MiniCPM5-1B` | wi4b32_wi8_afp32 (gpu-opt) | v0.16.0 | — | 54.5 | 218.8 | 110.0 | 364.2 | — | 2026-08-25 |
-| litert-lm-cpu | `litert-community/MiniCPM5-1B` | wi4b32_wi8_afp32 | v0.16.0 | — | 30.4 | 34.8 | 590.0 | 1047.3 | — | 2026-08-25 |
+| litert-lm-gpu | `litert-community/MiniCPM5-1B` | wi4b32_wi8_afp32 (gpu-opt) | v0.16.0 | — | 54.6 | 224.4 | 110.0 | 367.2 | — | 2026-08-25 |
+| litert-lm-cpu | `litert-community/MiniCPM5-1B` | wi4b32_wi8_afp32 | v0.16.0 | — | 75.5 | 40.7 | 515.0 | 1053.5 | — | 2026-08-25 |
 
 <details><summary>single-arm cells (no cross-runtime comparison)</summary>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | Qwen 3 0.6B | Mac Studio (M4 Max) | — | **555.9** (2026-08-17) | **309.9** (2026-08-17) | — |
 | Qwen 3 8B | Mac Studio (M4 Max) | — | 98.3 cold (2026-06-17) | 62.4 cold (2026-06-17) | — |
 
-¹ Qwen 3 0.6B · iPhone 17 Pro: the cells come from 5 capture sessions (Apple Core AI 2026-06-18 and 2026-07-13 (`2026-07-14-iphone-final`); MLX 2026-08-26 (`2026-08-26-iphone-lfm-pair`); LiteRT-LM 2026-08-26 (`2026-08-26-iphone-qwen-3runtime-pair`); Core ML 2026-06-17). Same device, different sittings — device state moved between sessions on this phone (`results/raw/2026-07-13-mlx-variance/`), so a ratio between two cells of this row is not a measurement; compare within one session (the Core AI section below carries the per-session tables).
+¹ Qwen 3 0.6B · iPhone 17 Pro: the cells come from 5 capture sessions (Apple Core AI 2026-06-18 and 2026-07-13 (`2026-07-14-iphone-final`); MLX 2026-08-26 (`2026-08-26-iphone-lfm-pair`); LiteRT-LM 2026-08-26 (`2026-08-26-iphone-qwen-3runtime-pair`); Core ML 2026-06-17). Same device, different sittings — device state moves between sessions (measured on the phone: `results/raw/2026-07-13-mlx-variance/`), so a ratio between two cells of this row is not a measurement; compare within one session (the dated tables below are per-session).
 
 <details><summary>Recipes behind the harness cells (quant-per-arm-rule)</summary>
 
@@ -26,6 +26,24 @@
 - Mac Studio (M4 Max) · Qwen 3 0.6B · LiteRT-LM: `litert-community/Qwen3-0.6B` — INT4 (mixed, blockwise gs32), engine v0.16.0, warm median of 3 in-process runs, session 2026-08-17 (`2026-08-17-mac-litert-v0160`)
 - Mac Studio (M4 Max) · Qwen 3 8B · MLX: `mlx-community/Qwen3-8B-4bit` — Q4, engine pre-stamp, cold, 3 fresh-process launches in that session (no warm runs), last one shown, session 2026-06-17
 - Mac Studio (M4 Max) · Qwen 3 8B · LiteRT-LM: `litert-community/Qwen3-8B` — INT4 (mixed, blockwise gs32), engine pre-stamp, cold, 3 fresh-process launches in that session (no warm runs), last one shown, session 2026-06-17
+
+</details>
+
+**Apple `llm-benchmark` protocol, Mac** — 512-token prompt, 1024 generated, 5 trials, greedy; Apple Core AI = Apple's `llm-benchmark` release build, MLX = `mlx_lm benchmark` with the same arguments. A different budget from the harness rows above (budget-mode-rule): never compare a number here with one there. Each cell is its newest campaign — the date in parentheses.
+
+| Model | Device | Apple Core AI | MLX |
+|---|---|---:|---:|
+| Qwen 3 0.6B ¹ | Mac Studio (M4 Max) | 503.1 (2026-07-13) | 432.3 (2026-06-11) |
+| Qwen 3 8B | Mac Studio (M4 Max) | 94.1 (2026-06-11) | 90.0 (2026-06-11) |
+
+¹ Qwen 3 0.6B · Mac Studio (M4 Max): the cells come from 2 capture sessions (Apple Core AI 2026-07-13 (`2026-07-13-mac-warm/coreai-ct041`); MLX 2026-06-11 (`2026-06-11-m4max-coreai-matrix`)). Same device, different sittings — device state moves between sessions (measured on the phone: `results/raw/2026-07-13-mlx-variance/`), so a ratio between two cells of this row is not a measurement; compare within one session (the dated tables below are per-session).
+
+<details><summary>Recipes behind the llm-benchmark cells</summary>
+
+- Mac Studio (M4 Max) · Qwen 3 0.6B · Apple Core AI: `qwen3_0_6b_dynamic_ct041` — Apple `llm-benchmark`, 512p/1024g, mean of 5 trials (trial spread 0.1%), `results/raw/2026-07-13-mac-warm/coreai-ct041/`
+- Mac Studio (M4 Max) · Qwen 3 0.6B · MLX: `mlx-community/Qwen3-0.6B-4bit` — `mlx_lm benchmark` (mlx-lm 0.31.3), same 512p/1024g/5 arguments, mean of the trials, `results/raw/2026-06-11-m4max-coreai-matrix/mlx_sweep_0.31.3.log`
+- Mac Studio (M4 Max) · Qwen 3 8B · Apple Core AI: `qwen3_8b_4bit_dynamic` — Apple `llm-benchmark`, 512p/1024g, mean of 5 trials (trial spread 0.3%), `results/raw/2026-06-11-m4max-coreai-matrix/`
+- Mac Studio (M4 Max) · Qwen 3 8B · MLX: `mlx-community/Qwen3-8B-4bit` — `mlx_lm benchmark` (mlx-lm 0.31.3), same 512p/1024g/5 arguments, mean of the trials, `results/raw/2026-06-11-m4max-coreai-matrix/mlx_sweep_0.31.3.log`
 
 </details>
 
@@ -64,7 +82,7 @@
 
 <!-- END GENERATED: scripts/render_headline.py -->
 
-Not in the generated table yet, because this repo holds no record for them: the Apple Core AI numbers for the hybrid models live on the model cards ([`mlboydaisuke/Nemotron-3-Nano-4B-CoreAI`](https://huggingface.co/mlboydaisuke/Nemotron-3-Nano-4B-CoreAI), [`coreai-community/granite-4.0-h-CoreAI`](https://huggingface.co/coreai-community/granite-4.0-h-CoreAI)), and the M4 Max Core AI `llm-benchmark` runs are quoted in the Core AI section below with their raw logs.
+Not in the generated tables, because this repo holds no record for them: the Apple Core AI numbers for the hybrid models live on the model cards ([`mlboydaisuke/Nemotron-3-Nano-4B-CoreAI`](https://huggingface.co/mlboydaisuke/Nemotron-3-Nano-4B-CoreAI), [`coreai-community/granite-4.0-h-CoreAI`](https://huggingface.co/coreai-community/granite-4.0-h-CoreAI)), and the macOS-26-era Qwen3-0.6B Core AI artifact (the 1,121 tok/s figure in the Core AI section) left only an archived hash, not a benchmark record.
 
 **On-device LLM benchmark for Apple Silicon — iPhone · iPad · Mac.**
 
@@ -88,7 +106,7 @@ A neutral, reproducible benchmark for running local LLMs (and, in time, ASR / TT
 | MLX | GPU | 167.2 | **158.8** | 489 MB | 2026-07-13 |
 | **Core AI** (static-shape) | ANE | 143.7 | blocked† | 1,158 MB | 2026-06-18 |
 | LiteRT-LM | GPU | 121.0 | 120.4 | 1,384 MB | 2026-07-13 |
-| **CoreML-LLM** | ANE | 39 | pending‡ | **184** 🏆 | 2026-06 |
+| **CoreML-LLM** | ANE | 37.7 | pending‡ | **184** 🏆 | 2026-06-17 |
 
 > **Read the Session column before comparing rows.** Cross-session ratios are invalid on this
 > device: the same MLX binary + pins measured 126–133 tok/s in mid-June and 159–180 today
@@ -98,10 +116,14 @@ A neutral, reproducible benchmark for running local LLMs (and, in time, ASR / TT
 > same-session Release warm gives **LiteRT-LM ≈ 0.76× MLX**. This replaces the earlier
 > Debug-contaminated MLX 112 row and the "~1.6× once warm" framing.
 >
-> † **Core AI warm re-capture is blocked**: `coreai-build` aborts on the current macOS 27
-> beta (both toolchain generations) so the 0.6B bundles can't be re-assembled —
-> [`methodology/coreai-build-regression-2026-07.md`](methodology/coreai-build-regression-2026-07.md).
-> Core AI cold/warm behaviour is instead re-verified at 4B (bundles survive on-device).
+> † **Core AI warm re-capture was blocked in July**: `coreai-build` aborted on the macOS 27
+> beta of the time (both toolchain generations), so the 0.6B bundles could not be re-assembled —
+> [`methodology/coreai-build-regression-2026-07.md`](methodology/coreai-build-regression-2026-07.md);
+> cold/warm behaviour was re-verified at 4B instead (bundles survive on-device). A warm capture
+> of the macOS-26-era GPU bundle exists from 2026-08-26
+> ([`results/raw/2026-08-26-iphone-coreai-pairs/`](results/raw/2026-08-26-iphone-coreai-pairs/summary.md):
+> 152.3 cold / 147.4 warm, engine 0.2.0+static-inputs-patch), but every cell of that session
+> started thermal-fair, so it fails the §2 guard and is not in the tables.
 > ‡ CoreML-LLM stateful-chunks bundle needs re-conversion before it can be re-measured.
 
 - **Core AI's GPU "pipelined" engine was the fastest path in the June session** — cold 193.3

--- a/scripts/bench_common.py
+++ b/scripts/bench_common.py
@@ -75,6 +75,27 @@ LOGICAL_MODELS: list[tuple[str, str]] = [
 ]
 
 
+# Historical flat-file device labels -> hardware identifiers, so label-space
+# rows and identifier-space rows of the SAME machine join. Factual basis, not
+# guesswork: the author's "m4max" machine was chassis-verified as a Mac Studio
+# Mac16,9 via system_profiler on 2026-08-15
+# (results/raw/2026-08-15-muse-glimmer-30b-3way/ENV.md). m3air (a MacBook Air,
+# different machine) is deliberately NOT aliased.
+DEVICE_ALIASES = {"m4max": "Mac16,9"}
+
+
+# fairness-rules §2 thermal guard (cold-warm-split), applied as code by
+# regression_diff.py, render_leaderboard.py and render_headline.py: only runs
+# that STARTED thermal-nominal are comparable. Rows with no thermal field
+# (pre-thermal writers, Mac CLI) pass through unchanged.
+NOMINAL_STATES = ("nominal", "")
+
+
+def started_nominal(rows):
+    """The rows of a cell whose run started thermal-nominal (or has no thermal field)."""
+    return [r for r in rows if (r.get("thermal_initial") or "") in NOMINAL_STATES]
+
+
 def logical_model(model_id: str) -> str:
     """Canonical display name for a model, collapsing per-runtime HF IDs."""
     needle = model_id.lower()

--- a/scripts/build_summary.py
+++ b/scripts/build_summary.py
@@ -20,7 +20,10 @@ Outputs (overwritten each run — derived data, raw stays canonical):
 Stdlib only. Idempotent. New writers should emit schema/result.v1.json natively;
 this script is the bridge for pre-v1 records.
 """
-import csv, glob, json, os
+import csv, glob, json, os, sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bench_common import DEVICE_ALIASES  # noqa: E402 — shared with render_headline
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUT = os.path.join(ROOT, "results", "summary")
@@ -88,15 +91,6 @@ def build_quality():
         w = csv.DictWriter(fh, fieldnames=fields)
         w.writeheader(); w.writerows(rows)
     return path, len(rows)
-
-
-# Historical flat-file device labels -> hardware identifiers, so label-space
-# rows and identifier-space rows of the SAME machine join. Factual basis, not
-# guesswork: the author's "m4max" machine was chassis-verified as a Mac Studio
-# Mac16,9 via system_profiler on 2026-08-15
-# (results/raw/2026-08-15-muse-glimmer-30b-3way/ENV.md). m3air (a MacBook Air,
-# different machine) is deliberately NOT aliased.
-DEVICE_ALIASES = {"m4max": "Mac16,9"}
 
 
 def platform_of(d):

--- a/scripts/regression_diff.py
+++ b/scripts/regression_diff.py
@@ -46,6 +46,9 @@ import os
 import statistics
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bench_common import NOMINAL_STATES  # noqa: E402 — one definition for differ + renderers
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SUMMARY = os.path.join(ROOT, "results", "summary")
 
@@ -195,12 +198,11 @@ GROUP = ("device", "runtime", "model_id", "task", "cold_run")
 
 
 # fairness-rules §2 thermal guard, applied as code: only runs that STARTED at
-# nominal are comparable. The runners record hot runs (failed-runs-stay) and
-# mark the cell THERMAL_FAIL, but a differ that pooled them anyway turned a
-# clean nominal warm set into "spread 21%, UNRELIABLE" (measured 2026-08-19:
-# 4 nominal + 5 fair runs of the same cell). Rows with no thermal field
-# (pre-thermal writers, Mac CLI) pass through unchanged.
-NOMINAL_STATES = ("nominal", "")
+# nominal are comparable (bench_common.NOMINAL_STATES). The runners record hot
+# runs (failed-runs-stay) and mark the cell THERMAL_FAIL, but a differ that
+# pooled them anyway turned a clean nominal warm set into "spread 21%,
+# UNRELIABLE" (measured 2026-08-19: 4 nominal + 5 fair runs of the same cell).
+# Rows with no thermal field (pre-thermal writers, Mac CLI) pass through.
 
 
 def cells(rows, metric):

--- a/scripts/render_headline.py
+++ b/scripts/render_headline.py
@@ -16,16 +16,22 @@ Sources (read-only):
                                     from render_leaderboard's latest_session / arm_row,
                                     so a number shown in both places is the same number.
   results/hybrid/*.json             the CLI hybrid-model reports (llama-bench / mlx_lm).
+  results/raw/**/*.json             Apple `llm-benchmark --output-json` records (detected by
+                                    shape, not path) + the `mlx_lm benchmark` sweep logs
+                                    beside them (mlx_sweep_<ver>.log): the Mac 512p/1024g
+                                    protocol, its own table (budget-mode-rule).
 
 Rules applied as code (slugs: methodology/fairness-rules.md):
   cold-warm-split      warm median where the session has warm runs, else the cold
                        number tagged "cold"; never pooled.
-  thermal guard (§2)   only runs that STARTED thermal-nominal count — the same filter
-                       regression_diff.py applies. A session whose runs all started
-                       hot is skipped and the cell falls back to its newest nominal
-                       session (results/raw/2026-08-26-iphone-coreai-pairs is
-                       THERMAL_FAIL on every cell by its own gate file; it must not
-                       become the headline).
+  thermal guard (§2)   only runs that STARTED thermal-nominal count — the filter
+                       bench_common.started_nominal, shared with render_leaderboard
+                       and regression_diff. A session whose runs all started hot is
+                       skipped and the cell falls back to its newest nominal session
+                       (results/raw/2026-08-26-iphone-coreai-pairs is THERMAL_FAIL on
+                       every cell by its own gate file; it must not be the headline).
+                       An arm with no nominal capture at all is listed under the
+                       table, not in it (the leaderboard shows it flagged ⚠hot).
   iphone-session-variance
                        every cell carries its capture date; a row whose cells come
                        from different sessions gets an automatic note, and no ratio
@@ -33,8 +39,8 @@ Rules applied as code (slugs: methodology/fairness-rules.md):
   quant-per-arm-rule   the recipe (artifact, quantization, engine, n) of every cell
                        is listed right under the table.
   stored-report-rule   a number with no record under results/ does not appear. Known
-                       gaps: the M4 Max Core AI `llm-benchmark` runs (no parser yet)
-                       and the hybrid-model Core AI cells (HF cards only).
+                       gaps: the hybrid-model Core AI cells (HF cards only) and the
+                       macOS-26-era Qwen3-0.6B artifact (archived hash, no record).
   no-cherry-pick       every artifact of a runtime is shown, fastest first; spread
                        over SPREAD_FLAG carries the same ⚠ as LEADERBOARD.md.
 
@@ -49,11 +55,12 @@ import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from bench_common import DEVICE_DISPLAY, logical_model  # noqa: E402
+from bench_common import DEVICE_ALIASES, DEVICE_DISPLAY, logical_model, started_nominal  # noqa: E402
 from render_leaderboard import SPREAD_FLAG, arm_row, fmt, latest_session, load  # noqa: E402
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 HYBRID = os.path.join(ROOT, "results", "hybrid")
+RAW = os.path.join(ROOT, "results", "raw")
 TARGET = os.path.join(ROOT, "README.md")
 BEGIN = "<!-- BEGIN GENERATED: scripts/render_headline.py -->"
 END = "<!-- END GENERATED: scripts/render_headline.py -->"
@@ -70,10 +77,11 @@ RUNTIME_LABEL = {
     "coreml-llm": "Core ML",
 }
 RUNTIME_ORDER = list(RUNTIME_LABEL)
-# fairness-rules §2 thermal guard, same states as regression_diff.NOMINAL_STATES:
-# rows with no thermal field (pre-thermal writers, Mac CLI) pass through.
-NOMINAL_STATES = ("nominal", "")
 SUPERSCRIPTS = "¹²³⁴⁵⁶⁷⁸⁹"
+LLM_BENCHMARK_KEYS = {"averages", "generation_tokens", "model", "num_trials", "prompt_tokens", "trials"}
+# llm-benchmark campaign dirs whose name carries no device label. Factual basis,
+# not guesswork: the ct041 README states "Mac Studio M4 Max, macOS 27.0 26A5378j".
+CAMPAIGN_DEVICE = {"2026-07-13-mac-warm/coreai-ct041": "Mac16,9"}
 
 
 def device_name(model_identifier):
@@ -106,7 +114,7 @@ def harness_rows():
             continue
         cells.setdefault((r["platform"], r["device"], model, r["runtime"], r["model_id"]), []).append(r)
     for (plat, dev, model, rt, mid), rows in cells.items():
-        ok = [r for r in rows if (r.get("thermal_initial") or "") in NOMINAL_STATES]
+        ok = started_nominal(rows)  # fairness §2 guard, shared with render_leaderboard
         if not ok:
             hot_only.append((plat, dev, model, rt, mid, arm_row(rows)["date"]))
             continue
@@ -156,6 +164,15 @@ def recipe_line(dev, model, rt, a, mid, sess, skipped):
     return line
 
 
+def session_note(model, dev_name, by_rt, n_sessions, marker):
+    by = "; ".join(f"{label} {' and '.join(dates)}" for label, dates in by_rt.items())
+    return (f"{marker} {model} · {dev_name}: the cells come from {n_sessions} capture "
+            f"sessions ({by}). Same device, different sittings — device state moves between "
+            "sessions (measured on the phone: `results/raw/2026-07-13-mlx-variance/`), so a "
+            "ratio between two cells of this row is not a measurement; compare within one "
+            "session (the dated tables below are per-session).")
+
+
 def render_harness(lines):
     tree, hot_only = harness_rows()
     runtimes = [rt for rt in RUNTIME_ORDER
@@ -195,14 +212,7 @@ def render_harness(lines):
         marker = ""
         if len(sessions) > 1:
             marker = " " + SUPERSCRIPTS[len(notes) % len(SUPERSCRIPTS)]
-            by = "; ".join(f"{label} {' and '.join(dates)}" for label, dates in by_rt.items())
-            notes.append(
-                f"{marker.strip()} {model} · {device_name(dev)}: the cells come from "
-                f"{len(sessions)} capture sessions ({by}). Same device, different sittings — "
-                "device state moved between sessions on this phone "
-                "(`results/raw/2026-07-13-mlx-variance/`), so a ratio between two cells of "
-                "this row is not a measurement; compare within one session (the Core AI "
-                "section below carries the per-session tables).")
+            notes.append(session_note(model, device_name(dev), by_rt, len(sessions), marker.strip()))
         cells = [cell_text(arms[rt]) if rt in arms else "—" for rt in runtimes]
         lines.append(f"| {model}{marker} | {device_name(dev)} | " + " | ".join(cells) + " |")
     lines.append("")
@@ -218,6 +228,116 @@ def render_harness(lines):
                          f"`{mid}` — newest capture {date} started hot")
         lines.append("")
     lines.append("<details><summary>Recipes behind the harness cells (quant-per-arm-rule)</summary>")
+    lines.append("")
+    lines.extend(recipes)
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+    return latest
+
+
+# ----------------------------------------------------------------------------
+# Apple llm-benchmark protocol (Mac): llm-benchmark JSON + mlx_lm benchmark sweep logs
+# ----------------------------------------------------------------------------
+
+def _campaign(path):
+    """results/raw/<campaign...>/file -> (campaign rel dir, date, device identifier)."""
+    rel = os.path.relpath(os.path.dirname(path), RAW)
+    top = rel.split(os.sep)[0]
+    date = top[:10] if re.match(r"\d{4}-\d{2}-\d{2}", top) else ""
+    device = CAMPAIGN_DEVICE.get(rel)
+    if device is None:
+        for tok in top.split("-"):
+            if tok in DEVICE_DISPLAY:
+                device = DEVICE_ALIASES.get(tok, tok)  # label-space -> identifier, as build_summary does
+                break
+    return rel, date, device or rel
+
+
+def llm_benchmark_cells():
+    """(device, model) -> runtime -> [(value, date, campaign, recipe)], one entry per
+    campaign; the caller keeps the newest campaign per runtime."""
+    cells = {}
+    for path in sorted(glob.glob(os.path.join(RAW, "**", "*.json"), recursive=True)):
+        try:
+            d = json.load(open(path))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(d, dict) or set(d) != LLM_BENCHMARK_KEYS:
+            continue
+        rel, date, device = _campaign(path)
+        stem = os.path.basename(path)[:-5].split("_")[0]
+        model = logical_model(stem)
+        if model not in HEADLINE_MODELS:
+            continue
+        vals = [t["gen_tps"] for t in d["trials"] if t.get("gen_tps")]
+        spread = (max(vals) - min(vals)) / d["averages"]["generation_tps"] * 100 if len(vals) > 1 else 0.0
+        recipe = (f"`{d['model']}` — Apple `llm-benchmark`, {d['prompt_tokens']}p/"
+                  f"{d['generation_tokens']}g, mean of {d['num_trials']} trials "
+                  f"(trial spread {spread:.1f}%), `results/raw/{rel}/`")
+        cells.setdefault((device, model), {}).setdefault("core-ai", []).append(
+            (d["averages"]["generation_tps"], date, rel, recipe))
+    for path in sorted(glob.glob(os.path.join(RAW, "**", "mlx_sweep_*.log"), recursive=True)):
+        rel, date, device = _campaign(path)
+        ver = re.search(r"mlx_sweep_([\d.]+)\.log$", path)
+        ver = ver.group(1) if ver else "?"
+        repo = None
+        for line in open(path):
+            m = re.match(r"=== (\S+) ", line)
+            if m:
+                repo = m.group(1)
+                continue
+            m = re.match(r"Averages: .*generation_tps=([\d.]+)", line)
+            if m and repo:
+                model = logical_model(repo)
+                if model in HEADLINE_MODELS:
+                    recipe = (f"`{repo}` — `mlx_lm benchmark` (mlx-lm {ver}), same 512p/1024g/5 "
+                              f"arguments, mean of the trials, `results/raw/{rel}/{os.path.basename(path)}`")
+                    cells.setdefault((device, model), {}).setdefault("mlx-swift", []).append(
+                        (float(m.group(1)), date, rel, recipe))
+                repo = None
+    return cells
+
+
+def render_llm_benchmark(lines):
+    cells = llm_benchmark_cells()
+    if not cells:
+        return ""
+    runtimes = [rt for rt in RUNTIME_ORDER if any(rt in arms for arms in cells.values())]
+    lines.append(
+        "**Apple `llm-benchmark` protocol, Mac** — 512-token prompt, 1024 generated, 5 trials, "
+        "greedy; Apple Core AI = Apple's `llm-benchmark` release build, MLX = `mlx_lm benchmark` "
+        "with the same arguments. A different budget from the harness rows above "
+        "(budget-mode-rule): never compare a number here with one there. Each cell is its newest "
+        "campaign — the date in parentheses.")
+    lines.append("")
+    lines.append("| Model | Device | " + " | ".join(RUNTIME_LABEL.get(rt, rt) for rt in runtimes) + " |")
+    lines.append("|---|---|" + "|".join("---:" for _ in runtimes) + "|")
+    notes, recipes = [], []
+    latest = ""
+    for (device, model) in sorted(cells, key=lambda k: (k[0], HEADLINE_MODELS.index(k[1]))):
+        arms = cells[(device, model)]
+        row, sessions, by_rt = [], set(), {}
+        for rt in runtimes:
+            if rt not in arms:
+                row.append("—")
+                continue
+            val, date, rel, recipe = max(arms[rt], key=lambda t: t[1])
+            sessions.add(rel)
+            by_rt.setdefault(RUNTIME_LABEL.get(rt, rt), []).append(f"{date} (`{rel}`)")
+            latest = max(latest, date)
+            row.append(f"{val:.1f} ({date})")
+            recipes.append(f"- {device_name(device)} · {model} · {RUNTIME_LABEL.get(rt, rt)}: {recipe}")
+        marker = ""
+        if len(sessions) > 1:
+            marker = " " + SUPERSCRIPTS[len(notes) % len(SUPERSCRIPTS)]
+            notes.append(session_note(model, device_name(device), by_rt, len(sessions), marker.strip()))
+        lines.append(f"| {model}{marker} | {device_name(device)} | " + " | ".join(row) + " |")
+    lines.append("")
+    for n in notes:
+        lines.append(n)
+        lines.append("")
+    lines.append("<details><summary>Recipes behind the llm-benchmark cells</summary>")
     lines.append("")
     lines.extend(recipes)
     lines.append("")
@@ -329,9 +449,7 @@ def render_hybrid(lines):
 
 def generate():
     body = []
-    latest_h = render_harness(body)
-    latest_x = render_hybrid(body)
-    latest = max(latest_h, latest_x)
+    latest = max(render_harness(body), render_llm_benchmark(body), render_hybrid(body))
     head = [
         BEGIN,
         "",

--- a/scripts/render_leaderboard.py
+++ b/scripts/render_leaderboard.py
@@ -15,6 +15,12 @@ Neutrality invariants (why cells look the way they do):
     the headline is the SHORT-CHAT task; other tasks live in RESULTS.md.
   - a warm median whose trial spread exceeds SPREAD_FLAG carries ⚠
     (spread-rule).
+  - only runs that started thermal-nominal count (fairness-rules §2, the
+    same guard regression_diff applies); a cell whose every capture started
+    hot stays in the table flagged ⚠hot instead of vanishing
+    (failed-runs-stay). Audited 2026-09-05: the 2026-08-26 iphone-coreai-pairs
+    session, THERMAL_FAIL on every cell by its own gate file, had become the
+    latest-session row for three cells.
   - GSM8K joins on (model_id, runtime); pre-v1 quality rows have no
     model_id and deliberately do not join (tag prose is not decoded).
 """
@@ -27,7 +33,7 @@ import statistics
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from bench_common import DEVICE_DISPLAY, corrected_quant, logical_model  # noqa: E402
+from bench_common import DEVICE_DISPLAY, corrected_quant, logical_model, started_nominal  # noqa: E402
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SUMMARY = os.path.join(ROOT, "results", "summary")
@@ -88,8 +94,12 @@ def latest_session(rows):
 
 
 def arm_row(rows):
-    """One leaderboard line from one cell's latest-session rows."""
-    sess, date = latest_session(rows)
+    """One leaderboard line from one cell's latest-session rows. The thermal
+    guard runs first: the newest session among nominal-start runs wins; a cell
+    with no nominal-start run at all is rendered from its hot runs and flagged."""
+    ok = started_nominal(rows)
+    hot = not ok
+    sess, date = latest_session(ok or rows)
     warm = [fnum(r["decode_tps"]) for r in sess if r["cold_run"] == "False"]
     warm = [v for v in warm if v]
     cold = [fnum(r["decode_tps"]) for r in sess if r["cold_run"] == "True"]
@@ -122,7 +132,7 @@ def arm_row(rows):
         "mem": statistics.median(mem) if mem else None,
         "quant": (" / ".join(quants) or "unrecorded") + ("†" if qcorr else ""),
         "engine": " / ".join(engines) or "pre-stamp",
-        "date": date, "n": len(sess),
+        "date": date, "n": len(sess), "hot": hot,
     }
 
 
@@ -191,7 +201,10 @@ def generate():
         "† = quantization label carries the audited in-place correction "
         "(Gemma-4 `.litertlm` is the wNa8o8 mobile schema; early rows recorded "
         "\"INT4 (QAT)\" — quant-label-rule). mem MB = phys_footprint on Apple rows, "
-        "RSS on Android rows (no footprint equivalent; methodology/android.md).",
+        "RSS on Android rows (no footprint equivalent; methodology/android.md). "
+        "Only runs that started thermal-nominal count (fairness-rules §2): each cell "
+        "is its newest nominal-start session; ⚠hot marks a cell whose every capture "
+        "started hot, kept in the table with its numbers (failed-runs-stay).",
         "",
     ]
     for plat in ("mac", "ios", "android"):
@@ -243,7 +256,7 @@ def generate():
                     lines.append(
                         f"| {rt} | `{mid}` | {a['quant']} | {a['engine']} | {warm_txt} | "
                         f"{fmt(a['cold'])} | {fmt(a['prefill'])} | {fmt(a['ttft'])} | "
-                        f"{fmt(a['mem'])} | {qtxt} | {a['date']} |")
+                        f"{fmt(a['mem'])} | {qtxt} | {a['date']}{' ⚠hot' if a['hot'] else ''} |")
                 lines.append("")
             if single:
                 lines.append("<details><summary>single-arm cells (no cross-runtime comparison)</summary>")
@@ -260,7 +273,7 @@ def generate():
                         if a["warm"] and a["spread"] > SPREAD_FLAG:
                             warm_txt += f" ⚠spread {a['spread']:.0f}%"
                         lines.append(f"| {model} | {rt} | `{mid}` | {a['quant']} | {a['engine']} | "
-                                     f"{warm_txt} | {fmt(a['cold'])} | {a['date']} |")
+                                     f"{warm_txt} | {fmt(a['cold'])} | {a['date']}{' ⚠hot' if a['hot'] else ''} |")
                 lines.append("")
                 lines.append("</details>")
                 lines.append("")


### PR DESCRIPTION
Follow-ups listed in #4.

## Thermal guard in the leaderboard (one policy for both generated surfaces)

`render_leaderboard.arm_row` now applies the fairness §2 thermal guard before picking the session: the newest session among nominal-start runs wins. A cell with no nominal-start capture at all stays in the table with its numbers and a `⚠hot` mark on the date (failed-runs-stay), instead of vanishing. The guard states live once, in `bench_common.NOMINAL_STATES` / `started_nominal`; `regression_diff.py` and `render_headline.py` import them.

Effect on LEADERBOARD.md: 15 cells move to an older nominal session, 4 cells are flagged `⚠hot`. The cell that motivated this — iPhone `core-ai/qwen3-0.6b-gpu` — goes from the 2026-08-26 hot session (147.4 warm) back to 2026-06-18 (193.3 cold), the same number the README headline shows.

## Mac Core AI cells return to the headline, under their own protocol

`render_headline.py` gains a third table, **Apple `llm-benchmark` protocol, Mac** (512p / 1024g / 5 trials): Core AI cells from every `llm-benchmark --output-json` record under `results/raw/` (detected by shape, not path), MLX cells from the `mlx_sweep_<ver>.log` beside them. Newest campaign per cell, session date in every cell, the same automatic note when a row mixes sessions, recipes below.

| Model | Apple Core AI | MLX |
|---|---|---|
| Qwen 3 0.6B | 503.1 (2026-07-13, ct041 re-export) | 432.3 (2026-06-11) |
| Qwen 3 8B | 94.1 (2026-06-11) | 90.0 (2026-06-11) |

The macOS-26-era 0.6B artifact (the 1,121 tok/s figure) left an archived hash but no benchmark record, so it stays in the body only; the pointer paragraph under the block says so. `DEVICE_ALIASES` (m4max → Mac16,9) moves to `bench_common` so `build_summary` and the headline resolve the label the same way.

## Body text older than the records

- The Core AI section's "warm re-capture is blocked" note now says it was blocked in July and names the 2026-08-26 warm capture (152.3 cold / 147.4 warm) with the reason it is not in the tables (every cell started thermal-fair).
- Core ML cold cell in the June table: 39 → 37.7 (`results/raw/iphone17pro-coreml-llm-qwen3-0.6b-short-chat-run1.jsonl`, the nominal-start run; the three cold launches read 37.7 / 36.4 / 37.8), session 2026-06-17.

Not changed: the Core AI ANE "143.7" in the same table has no record in `results/summary` (the only per-run file is under `results/raw/superseded/`), and the 184 MB Core ML footprint is not in the summary rows either. Both left as written.

## Checks

All seven workflow jobs reproduced locally, plus `regression_diff.py --help` (import path).
